### PR TITLE
Clean up AI chat memory after orchestration

### DIFF
--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiMemoryService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiMemoryService.java
@@ -1,0 +1,6 @@
+package io.quintkard.quintkardapp.aimodel;
+
+public interface AiMemoryService {
+
+    void clear(AiMemoryScope memoryScope);
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelConfiguration.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelConfiguration.java
@@ -1,6 +1,7 @@
 package io.quintkard.quintkardapp.aimodel;
 
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.context.annotation.Bean;
@@ -10,9 +11,14 @@ import org.springframework.context.annotation.Configuration;
 public class AiModelConfiguration {
 
     @Bean
-    ChatMemory chatMemory() {
+    ChatMemoryRepository chatMemoryRepository() {
+        return new InMemoryChatMemoryRepository();
+    }
+
+    @Bean
+    ChatMemory chatMemory(ChatMemoryRepository chatMemoryRepository) {
         return MessageWindowChatMemory.builder()
-                .chatMemoryRepository(new InMemoryChatMemoryRepository())
+                .chatMemoryRepository(chatMemoryRepository)
                 .maxMessages(100)
                 .build();
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiMemoryService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiMemoryService.java
@@ -1,0 +1,22 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SpringAiMemoryService implements AiMemoryService {
+
+    private final ChatMemoryRepository chatMemoryRepository;
+
+    public SpringAiMemoryService(ChatMemoryRepository chatMemoryRepository) {
+        this.chatMemoryRepository = chatMemoryRepository;
+    }
+
+    @Override
+    public void clear(AiMemoryScope memoryScope) {
+        if (memoryScope == null || memoryScope.conversationId() == null || memoryScope.conversationId().isBlank()) {
+            return;
+        }
+        chatMemoryRepository.deleteByConversationId(memoryScope.conversationId());
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImpl.java
@@ -4,6 +4,7 @@ import io.quintkard.quintkardapp.agent.AgentConfig;
 import io.quintkard.quintkardapp.agentexecution.AgentExecutionResult;
 import io.quintkard.quintkardapp.aimodel.AiMessage;
 import io.quintkard.quintkardapp.aimodel.AiMessageRole;
+import io.quintkard.quintkardapp.aimodel.AiMemoryService;
 import io.quintkard.quintkardapp.aimodel.AiStructuredChatRequest;
 import io.quintkard.quintkardapp.aimodel.AiChatService;
 import io.quintkard.quintkardapp.logging.LogContext;
@@ -28,15 +29,18 @@ public class OrchestratorExecutionServiceImpl implements OrchestratorExecutionSe
     private static final Logger logger = LoggerFactory.getLogger(OrchestratorExecutionServiceImpl.class);
 
     private final AiChatService aiChatService;
+    private final AiMemoryService aiMemoryService;
     private final AgentDispatchService agentDispatchService;
     private final MessageProcessingContextFactory contextFactory;
 
     public OrchestratorExecutionServiceImpl(
             AiChatService aiChatService,
+            AiMemoryService aiMemoryService,
             AgentDispatchService agentDispatchService,
             MessageProcessingContextFactory contextFactory
     ) {
         this.aiChatService = aiChatService;
+        this.aiMemoryService = aiMemoryService;
         this.agentDispatchService = agentDispatchService;
         this.contextFactory = contextFactory;
     }
@@ -65,6 +69,8 @@ public class OrchestratorExecutionServiceImpl implements OrchestratorExecutionSe
             return new OrchestratorExecutionResult(filteringDecision, routingDecision, agentResults);
         } catch (Exception exception) {
             throw new IllegalStateException("Failed to manage orchestration logging context", exception);
+        } finally {
+            aiMemoryService.clear(context.memoryScope());
         }
     }
 

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImplTest.java
@@ -14,6 +14,7 @@ import io.quintkard.quintkardapp.agentexecution.AgentExecutionResult;
 import io.quintkard.quintkardapp.agentexecution.AgentExecutionStatus;
 import io.quintkard.quintkardapp.aimodel.AiChatService;
 import io.quintkard.quintkardapp.aimodel.AiMemoryScope;
+import io.quintkard.quintkardapp.aimodel.AiMemoryService;
 import io.quintkard.quintkardapp.message.Message;
 import io.quintkard.quintkardapp.message.MessageStatus;
 import io.quintkard.quintkardapp.messagepipeline.MessageProcessingContext;
@@ -34,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class OrchestratorExecutionServiceImplTest {
 
     private AiChatService aiChatService;
+    private AiMemoryService aiMemoryService;
     private AgentDispatchService agentDispatchService;
     private MessageProcessingContextFactory contextFactory;
     private OrchestratorExecutionServiceImpl orchestratorExecutionService;
@@ -41,10 +43,11 @@ class OrchestratorExecutionServiceImplTest {
     @BeforeEach
     void setUp() {
         aiChatService = mock(AiChatService.class);
+        aiMemoryService = mock(AiMemoryService.class);
         agentDispatchService = mock(AgentDispatchService.class);
         contextFactory = mock(MessageProcessingContextFactory.class);
         orchestratorExecutionService =
-                new OrchestratorExecutionServiceImpl(aiChatService, agentDispatchService, contextFactory);
+                new OrchestratorExecutionServiceImpl(aiChatService, aiMemoryService, agentDispatchService, contextFactory);
     }
 
     @Test
@@ -60,6 +63,7 @@ class OrchestratorExecutionServiceImplTest {
         assertEquals("Message rejected by filtering step", result.routingDecision().reason());
         assertTrue(result.agentResults().isEmpty());
         verify(agentDispatchService, never()).dispatch(any(), any(), any(), any());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -89,6 +93,7 @@ class OrchestratorExecutionServiceImplTest {
         ArgumentCaptor<RoutingDecision> routingCaptor = ArgumentCaptor.forClass(RoutingDecision.class);
         verify(agentDispatchService).dispatch(any(), routingCaptor.capture(), any(), any());
         assertEquals(List.of(finance.getId(), ops.getId()), routingCaptor.getValue().agentIds());
+        verify(aiMemoryService).clear(context.memoryScope());
     }
 
     @Test
@@ -113,6 +118,7 @@ class OrchestratorExecutionServiceImplTest {
         assertTrue(result.filteringDecision().accepted());
         assertEquals("Filtering disabled", result.filteringDecision().reason());
         verify(aiChatService).chatForObject(any());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -137,6 +143,7 @@ class OrchestratorExecutionServiceImplTest {
         assertTrue(result.filteringDecision().accepted());
         assertEquals("Filtering disabled", result.filteringDecision().reason());
         verify(aiChatService).chatForObject(any());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -152,6 +159,7 @@ class OrchestratorExecutionServiceImplTest {
         assertEquals(List.of(), result.routingDecision().agentIds());
         assertEquals("No active agents configured", result.routingDecision().reason());
         verify(agentDispatchService).dispatch(any(), any(), any(), any());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -169,6 +177,7 @@ class OrchestratorExecutionServiceImplTest {
 
         assertEquals(List.of(), result.routingDecision().agentIds());
         assertEquals("No routing reason provided", result.routingDecision().reason());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -186,6 +195,7 @@ class OrchestratorExecutionServiceImplTest {
 
         assertEquals(List.of(finance.getId()), result.routingDecision().agentIds());
         assertEquals("No routing reason provided", result.routingDecision().reason());
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -204,6 +214,7 @@ class OrchestratorExecutionServiceImplTest {
         );
 
         assertEquals("Failed to manage orchestration logging context", exception.getMessage());
+        verify(aiMemoryService).clear(invalidContext.memoryScope());
     }
 
     @Test
@@ -232,6 +243,7 @@ class OrchestratorExecutionServiceImplTest {
         assertTrue(routingPrompt.contains("Name: Finance"));
         assertTrue(routingPrompt.contains("Description: Finance description"));
         assertTrue(routingPrompt.contains("Payload:\nPlease follow up on the invoice from last August."));
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     @Test
@@ -257,6 +269,7 @@ class OrchestratorExecutionServiceImplTest {
         String filteringPrompt = requests.get(0).messages().get(1).content();
         assertTrue(filteringPrompt.contains("Summary: \n"));
         assertTrue(filteringPrompt.contains("Payload:\n"));
+        verify(aiMemoryService).clear(context().memoryScope());
     }
 
     private MessageProcessingContext context() {


### PR DESCRIPTION
This PR adds explicit cleanup for AI chat memory after each message-processing orchestration run. The orchestrator now clears the run-scoped conversation in a finally block, so shared memory is still available across filtering, routing, and agent execution for a single message, but it does not accumulate in the in-memory repository after the run completes. To support that, the change introduces a small AiMemoryService abstraction backed by Spring AI’s ChatMemoryRepository, and updates the existing orchestration tests to verify cleanup on both success and failure paths.