### PR TITLE
Document Gemini auth setup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Quintkard is a local-first workflow assistant for turning inbound messages into 
 - Java 21
 - Node.js
 - PostgreSQL with a `quintkard` database
-- Google Cloud ADC or equivalent Vertex AI auth for AI model access
+- Google Cloud auth for Gemini access
 
 Default backend local DB settings are currently:
 
@@ -50,6 +50,33 @@ Default backend local DB settings are currently:
 - password: `quintkard`
 
 The backend also enables the PostgreSQL `vector` extension on connection startup.
+
+## AI setup
+
+The backend is currently configured to use Gemini through Vertex AI.
+
+### Option 1: Vertex AI with Application Default Credentials
+
+Authenticate with Google Cloud locally:
+
+```bash
+gcloud auth application-default login
+```
+
+You should also make sure the configured Google Cloud project has Vertex AI access enabled.
+
+### Option 2: Gemini Developer API / AI Studio key
+
+The backend properties also include a commented-out AI Studio API key configuration.
+If you want to use that path instead of Vertex AI:
+
+1. Uncomment the `spring.ai.google.genai.api-key` properties in `quintkard-app/src/main/resources/application.properties`
+2. Disable the active Vertex AI properties
+3. Export an API key:
+
+```bash
+export GOOGLE_API_KEY=your_key_here
+```
 
 ## Run locally
 

--- a/quintkard-app/src/main/resources/application.properties
+++ b/quintkard-app/src/main/resources/application.properties
@@ -19,8 +19,14 @@ spring.datasource.hikari.connection-init-sql=CREATE EXTENSION IF NOT EXISTS vect
 spring.jpa.hibernate.ddl-auto=update
 
 # Embeddings
+# Vertex AI configuration (configure google application default credentials if using vertex AI)
 spring.ai.model.chat=google-genai
 spring.ai.model.embedding.text=google-genai
+# Gemini Developer API / AI Studio key configuration
+# spring.ai.google.genai.api-key=${GOOGLE_API_KEY:}
+# spring.ai.google.genai.embedding.api-key=${GOOGLE_API_KEY:}
+
+# Vertex AI configuration
 spring.ai.google.genai.vertex-ai=true
 spring.ai.google.genai.project-id=bpk-poc-project
 spring.ai.google.genai.location=us-central1


### PR DESCRIPTION
## Summary

This PR documents and preserves both Gemini authentication paths in the project:

- active Vertex AI configuration
- commented AI Studio API key configuration

It also updates the repo README with setup instructions for both approaches.

## Changes

- keep Vertex AI properties active in 
- keep AI Studio API key properties commented for optional use
- document Vertex ADC setup in the root README
- document how to switch to AI Studio API key auth
- expand the README with local Docker Compose startup steps and roadmap updates

## Notes

- current default remains Vertex AI
- API key setup is documented but not active by default