### PR TITLE
Add multi-provider chat model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ The backend also enables the PostgreSQL `vector` extension on connection startup
 
 The backend is currently configured to use Gemini through Vertex AI.
 
+Suggested configuration by usage:
+
+- Use `Gemini on Vertex AI` if you want to run against a Google Cloud project, use GCP credits, or keep both chat and embeddings on the same Google-managed setup.
+- Use `Gemini Developer API / AI Studio key` if you want the simplest local API-key setup without Google Cloud ADC.
+- Use `OpenAI` if you want to run `gpt-*` chat models. In the current app, chat can be multi-provider, while embeddings are still configured separately and should stay pinned to one provider.
+
 ### Option 1: Vertex AI with Application Default Credentials
 
 Authenticate with Google Cloud locally:
@@ -77,6 +83,21 @@ If you want to use that path instead of Vertex AI:
 ```bash
 export GOOGLE_API_KEY=your_key_here
 ```
+
+### Option 3: OpenAI API key
+
+The backend also supports OpenAI chat models alongside Gemini.
+
+1. Export an API key:
+
+```bash
+export OPENAI_API_KEY=your_key_here
+```
+
+2. Make sure the OpenAI-related model entries remain present in `quintkard-app/src/main/resources/application.properties`
+3. Configure agents or orchestrator steps to use a supported `gpt-*` model
+
+OpenAI is currently used for chat only. Embeddings should remain pinned to a single configured provider.
 
 ## Run locally
 

--- a/quintkard-app/build.gradle
+++ b/quintkard-app/build.gradle
@@ -40,8 +40,10 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
     implementation 'org.springframework.ai:spring-ai-google-genai-embedding'
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImpl.java
@@ -149,8 +149,9 @@ public class AgentLoopExecutorImpl implements AgentLoopExecutor {
         List<Map<String, Object>> toolResponseParts = new ArrayList<>();
         for (AiToolCall toolCall : toolCalls) {
             Object result = executeToolCall(context, toolCall, allowedTools);
-            toolResults.add(new AiToolResult(toolCall.toolName(), result));
+            toolResults.add(new AiToolResult(toolCall.toolCallId(), toolCall.toolName(), result));
             toolResponseParts.add(Map.of(
+                    "toolCallId", toolCall.toolCallId() == null ? toolCall.toolName() : toolCall.toolCallId(),
                     "toolName", toolCall.toolName(),
                     "result", result
             ));

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiChatModelRegistry.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiChatModelRegistry.java
@@ -1,0 +1,10 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import org.springframework.ai.chat.model.ChatModel;
+
+public interface AiChatModelRegistry {
+
+    ChatModel get(String modelName);
+
+    AiProvider providerFor(String modelName);
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiChatOptionsFactory.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiChatOptionsFactory.java
@@ -1,0 +1,16 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+public interface AiChatOptionsFactory {
+
+    ChatOptions build(
+            AiProvider provider,
+            String userId,
+            String model,
+            double temperature,
+            AiToolScope toolScope,
+            String responseSchema,
+            String responseMimeType
+    );
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelCatalogProperties.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelCatalogProperties.java
@@ -1,0 +1,19 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "quintkard.ai")
+public class AiModelCatalogProperties {
+
+    private Map<String, AiModelDefinition> models = new LinkedHashMap<>();
+
+    public Map<String, AiModelDefinition> getModels() {
+        return models;
+    }
+
+    public void setModels(Map<String, AiModelDefinition> models) {
+        this.models = models;
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelConfiguration.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelConfiguration.java
@@ -1,13 +1,31 @@
 package io.quintkard.quintkardapp.aimodel;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
+@EnableConfigurationProperties({
+        AiModelCatalogProperties.class,
+        OpenAiChatConnectionProperties.class
+})
 public class AiModelConfiguration {
 
     @Bean
@@ -21,5 +39,51 @@ public class AiModelConfiguration {
                 .chatMemoryRepository(chatMemoryRepository)
                 .maxMessages(100)
                 .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.ai.openai", name = "api-key")
+    @ConditionalOnMissingBean(OpenAiApi.class)
+    OpenAiApi openAiApi(
+            OpenAiChatConnectionProperties properties,
+            RestClient.Builder restClientBuilder,
+            WebClient.Builder webClientBuilder
+    ) {
+        if (!StringUtils.hasText(properties.getApiKey())) {
+            throw new IllegalStateException("spring.ai.openai.api-key must not be blank");
+        }
+
+        return OpenAiApi.builder()
+                .baseUrl(properties.getBaseUrl())
+                .apiKey(properties.getApiKey())
+                .restClientBuilder(restClientBuilder)
+                .webClientBuilder(webClientBuilder)
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.ai.openai", name = "api-key")
+    @ConditionalOnMissingBean(OpenAiChatModel.class)
+    OpenAiChatModel openAiChatModel(
+            OpenAiApi openAiApi,
+            ToolCallingManager toolCallingManager,
+            ObjectProvider<RetryTemplate> retryTemplateProvider,
+            ObjectProvider<ObservationRegistry> observationRegistryProvider,
+            ObjectProvider<ToolExecutionEligibilityPredicate> toolExecutionEligibilityPredicateProvider
+    ) {
+        OpenAiChatModel.Builder builder = OpenAiChatModel.builder()
+                .openAiApi(openAiApi)
+                .defaultOptions(OpenAiChatOptions.builder().build())
+                .toolCallingManager(toolCallingManager)
+                .retryTemplate(retryTemplateProvider.getIfAvailable(RetryTemplate::new))
+                .observationRegistry(observationRegistryProvider.getIfAvailable(ObservationRegistry::create));
+
+        ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate =
+                toolExecutionEligibilityPredicateProvider.getIfAvailable();
+        if (toolExecutionEligibilityPredicate != null) {
+            builder.toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate);
+        }
+
+        return builder.build();
     }
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelDefinition.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelDefinition.java
@@ -1,0 +1,6 @@
+package io.quintkard.quintkardapp.aimodel;
+
+public record AiModelDefinition(
+        AiProvider provider
+) {
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiProvider.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiProvider.java
@@ -1,0 +1,6 @@
+package io.quintkard.quintkardapp.aimodel;
+
+public enum AiProvider {
+    GOOGLE_GENAI,
+    OPENAI
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiToolCall.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiToolCall.java
@@ -3,6 +3,7 @@ package io.quintkard.quintkardapp.aimodel;
 import java.util.Map;
 
 public record AiToolCall(
+        String toolCallId,
         String toolName,
         Map<String, Object> arguments
 ) {

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiToolResult.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiToolResult.java
@@ -1,6 +1,7 @@
 package io.quintkard.quintkardapp.aimodel;
 
 public record AiToolResult(
+        String toolCallId,
         String toolName,
         Object result
 ) {

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistry.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistry.java
@@ -1,0 +1,63 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultAiChatModelRegistry implements AiChatModelRegistry {
+
+    private final AiModelCatalogProperties modelCatalogProperties;
+    private final ObjectProvider<GoogleGenAiChatModel> googleChatModelProvider;
+    private final ObjectProvider<OpenAiChatModel> openAiChatModelProvider;
+
+    public DefaultAiChatModelRegistry(
+            AiModelCatalogProperties modelCatalogProperties,
+            ObjectProvider<GoogleGenAiChatModel> googleChatModelProvider,
+            ObjectProvider<OpenAiChatModel> openAiChatModelProvider
+    ) {
+        this.modelCatalogProperties = modelCatalogProperties;
+        this.googleChatModelProvider = googleChatModelProvider;
+        this.openAiChatModelProvider = openAiChatModelProvider;
+    }
+
+    @Override
+    public ChatModel get(String modelName) {
+        return switch (providerFor(modelName)) {
+            case GOOGLE_GENAI -> requireConfiguredModel(
+                    modelName,
+                    "Google GenAI",
+                    googleChatModelProvider.getIfAvailable()
+            );
+            case OPENAI -> requireConfiguredModel(
+                    modelName,
+                    "OpenAI",
+                    openAiChatModelProvider.getIfAvailable()
+            );
+        };
+    }
+
+    @Override
+    public AiProvider providerFor(String modelName) {
+        if (modelName == null || modelName.isBlank()) {
+            throw new IllegalArgumentException("AI model is required");
+        }
+
+        AiModelDefinition definition = modelCatalogProperties.getModels().get(modelName.trim());
+        if (definition == null || definition.provider() == null) {
+            throw new IllegalArgumentException("Unsupported AI model: " + modelName);
+        }
+        return definition.provider();
+    }
+
+    private ChatModel requireConfiguredModel(String modelName, String providerName, ChatModel chatModel) {
+        if (chatModel == null) {
+            throw new IllegalStateException(
+                    "%s chat model is not configured for requested model %s".formatted(providerName, modelName)
+            );
+        }
+        return chatModel;
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactory.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactory.java
@@ -1,0 +1,143 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import io.quintkard.quintkardapp.agenttool.AiTool;
+import io.quintkard.quintkardapp.agenttool.AiToolExecutionRequest;
+import io.quintkard.quintkardapp.agenttool.AiToolScopeResolver;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultAiChatOptionsFactory implements AiChatOptionsFactory {
+
+    private final AiToolScopeResolver toolScopeResolver;
+
+    public DefaultAiChatOptionsFactory(AiToolScopeResolver toolScopeResolver) {
+        this.toolScopeResolver = toolScopeResolver;
+    }
+
+    @Override
+    public ChatOptions build(
+            AiProvider provider,
+            String userId,
+            String model,
+            double temperature,
+            AiToolScope toolScope,
+            String responseSchema,
+            String responseMimeType
+    ) {
+        ToolOptions toolOptions = resolveToolOptions(userId, toolScope);
+
+        return switch (provider) {
+            case GOOGLE_GENAI -> buildGoogleOptions(
+                    userId,
+                    model,
+                    temperature,
+                    toolOptions,
+                    responseSchema,
+                    responseMimeType
+            );
+            case OPENAI -> buildOpenAiOptions(
+                    userId,
+                    model,
+                    temperature,
+                    toolOptions,
+                    responseSchema
+            );
+        };
+    }
+
+    private GoogleGenAiChatOptions buildGoogleOptions(
+            String userId,
+            String model,
+            double temperature,
+            ToolOptions toolOptions,
+            String responseSchema,
+            String responseMimeType
+    ) {
+        GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder()
+                .model(model)
+                .temperature(temperature)
+                .internalToolExecutionEnabled(false)
+                .labels(Map.of("userId", userId));
+
+        if (responseSchema != null) {
+            builder.responseSchema(responseSchema);
+        }
+
+        if (responseMimeType != null) {
+            builder.responseMimeType(responseMimeType);
+        }
+
+        if (!toolOptions.allowedToolNames().isEmpty()) {
+            builder.toolNames(toolOptions.allowedToolNames());
+            builder.toolCallbacks(toolOptions.toolCallbacks());
+            builder.toolContext(Map.of("userId", userId));
+        }
+
+        return builder.build();
+    }
+
+    private OpenAiChatOptions buildOpenAiOptions(
+            String userId,
+            String model,
+            double temperature,
+            ToolOptions toolOptions,
+            String responseSchema
+    ) {
+        OpenAiChatOptions.Builder builder = OpenAiChatOptions.builder()
+                .model(model)
+                .temperature(temperature)
+                .internalToolExecutionEnabled(false)
+                .user(userId);
+
+        if (responseSchema != null) {
+            builder.outputSchema(responseSchema);
+        }
+
+        if (!toolOptions.allowedToolNames().isEmpty()) {
+            builder.toolNames(toolOptions.allowedToolNames());
+            builder.toolCallbacks(toolOptions.toolCallbacks());
+            builder.toolContext(Map.of("userId", userId));
+        }
+
+        return builder.build();
+    }
+
+    private ToolOptions resolveToolOptions(String userId, AiToolScope toolScope) {
+        if (toolScope == null || toolScope.allowedToolNames() == null || toolScope.allowedToolNames().isEmpty()) {
+            return new ToolOptions(Set.of(), List.of());
+        }
+
+        List<AiTool> tools = toolScopeResolver.resolveTools(userId, toolScope.allowedToolNames());
+        Set<String> allowedToolNames = new LinkedHashSet<>();
+        List<ToolCallback> toolCallbacks = new ArrayList<>();
+
+        for (AiTool tool : tools) {
+            allowedToolNames.add(tool.name());
+            toolCallbacks.add(FunctionToolCallback
+                    .builder(tool.name(), (Map<String, Object> arguments) -> tool.execute(
+                            new AiToolExecutionRequest(userId, null, arguments)
+                    ))
+                    .description(tool.description())
+                    .inputType(tool.inputType())
+                    .build());
+        }
+
+        return new ToolOptions(allowedToolNames, toolCallbacks);
+    }
+
+    private record ToolOptions(
+            Set<String> allowedToolNames,
+            List<ToolCallback> toolCallbacks
+    ) {
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactory.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactory.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class DefaultAiChatOptionsFactory implements AiChatOptionsFactory {
 
+    private static final String USER_ID_CONTEXT_KEY = "userId";
+
     private final AiToolScopeResolver toolScopeResolver;
 
     public DefaultAiChatOptionsFactory(AiToolScopeResolver toolScopeResolver) {
@@ -67,7 +69,7 @@ public class DefaultAiChatOptionsFactory implements AiChatOptionsFactory {
                 .model(model)
                 .temperature(temperature)
                 .internalToolExecutionEnabled(false)
-                .labels(Map.of("userId", userId));
+                .labels(Map.of(USER_ID_CONTEXT_KEY, userId));
 
         if (responseSchema != null) {
             builder.responseSchema(responseSchema);
@@ -80,7 +82,7 @@ public class DefaultAiChatOptionsFactory implements AiChatOptionsFactory {
         if (!toolOptions.allowedToolNames().isEmpty()) {
             builder.toolNames(toolOptions.allowedToolNames());
             builder.toolCallbacks(toolOptions.toolCallbacks());
-            builder.toolContext(Map.of("userId", userId));
+            builder.toolContext(Map.of(USER_ID_CONTEXT_KEY, userId));
         }
 
         return builder.build();
@@ -106,7 +108,7 @@ public class DefaultAiChatOptionsFactory implements AiChatOptionsFactory {
         if (!toolOptions.allowedToolNames().isEmpty()) {
             builder.toolNames(toolOptions.allowedToolNames());
             builder.toolCallbacks(toolOptions.toolCallbacks());
-            builder.toolContext(Map.of("userId", userId));
+            builder.toolContext(Map.of(USER_ID_CONTEXT_KEY, userId));
         }
 
         return builder.build();

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/OpenAiChatConnectionProperties.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/OpenAiChatConnectionProperties.java
@@ -1,0 +1,26 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.ai.openai")
+public class OpenAiChatConnectionProperties {
+
+    private String apiKey;
+    private String baseUrl = "https://api.openai.com";
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiChatService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiChatService.java
@@ -1,14 +1,8 @@
 package io.quintkard.quintkardapp.aimodel;
 
-import io.quintkard.quintkardapp.agenttool.AiTool;
-import io.quintkard.quintkardapp.agenttool.AiToolExecutionRequest;
-import io.quintkard.quintkardapp.agenttool.AiToolScopeResolver;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -17,11 +11,9 @@ import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
-import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.ObjectMapper;
 
@@ -29,19 +21,19 @@ import tools.jackson.databind.ObjectMapper;
 public class SpringAiChatService implements AiChatService {
 
     private final ChatMemory chatMemory;
-    private final ChatModel chatModel;
-    private final AiToolScopeResolver toolScopeResolver;
+    private final AiChatModelRegistry chatModelRegistry;
+    private final AiChatOptionsFactory chatOptionsFactory;
     private final ObjectMapper objectMapper;
 
     public SpringAiChatService(
             ChatMemory chatMemory,
-            ChatModel chatModel,
-            AiToolScopeResolver toolScopeResolver,
+            AiChatModelRegistry chatModelRegistry,
+            AiChatOptionsFactory chatOptionsFactory,
             ObjectMapper objectMapper
     ) {
         this.chatMemory = chatMemory;
-        this.chatModel = chatModel;
-        this.toolScopeResolver = toolScopeResolver;
+        this.chatModelRegistry = chatModelRegistry;
+        this.chatOptionsFactory = chatOptionsFactory;
         this.objectMapper = objectMapper;
     }
 
@@ -58,6 +50,7 @@ public class SpringAiChatService implements AiChatService {
                 null
         );
 
+        ChatModel chatModel = chatModelRegistry.get(request.model());
         ChatResponse response = chatModel.call(prompt);
         AssistantMessage assistantMessage = response.getResult().getOutput();
         persistAssistantMessage(request.memoryScope(), assistantMessage);
@@ -88,6 +81,7 @@ public class SpringAiChatService implements AiChatService {
                 "application/json"
         );
 
+        ChatModel chatModel = chatModelRegistry.get(request.model());
         ChatResponse response = chatModel.call(prompt);
         AssistantMessage assistantMessage = response.getResult().getOutput();
         persistAssistantMessage(request.memoryScope(), assistantMessage);
@@ -141,62 +135,18 @@ public class SpringAiChatService implements AiChatService {
             }
         }
 
-        return new Prompt(
-                promptMessages,
-                buildOptions(userId, model, temperature, toolScope, responseSchema, responseMimeType)
+        AiProvider provider = chatModelRegistry.providerFor(model);
+        ChatOptions options = chatOptionsFactory.build(
+                provider,
+                userId,
+                model,
+                temperature,
+                toolScope,
+                responseSchema,
+                responseMimeType
         );
-    }
 
-    private GoogleGenAiChatOptions buildOptions(
-            String userId,
-            String model,
-            double temperature,
-            AiToolScope toolScope,
-            String responseSchema,
-            String responseMimeType
-    ) {
-        GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder()
-                .model(model)
-                .temperature(temperature)
-                .internalToolExecutionEnabled(false)
-                .labels(Map.of("userId", userId));
-
-        if (responseSchema != null) {
-            builder.responseSchema(responseSchema);
-        }
-
-        if (responseMimeType != null) {
-            builder.responseMimeType(responseMimeType);
-        }
-
-        if (toolScope != null && toolScope.allowedToolNames() != null && !toolScope.allowedToolNames().isEmpty()) {
-            List<AiTool> tools = toolScopeResolver.resolveTools(userId, toolScope.allowedToolNames());
-            Set<String> allowedToolNames = new LinkedHashSet<>();
-            List<ToolCallback> toolCallbacks = new ArrayList<>();
-            Map<String, Object> toolContext = new LinkedHashMap<>();
-
-            for (AiTool tool : tools) {
-                allowedToolNames.add(tool.name());
-                toolCallbacks.add(FunctionToolCallback
-                        .builder(tool.name(), (Map<String, Object> arguments) -> tool.execute(
-                                new AiToolExecutionRequest(
-                                        userId,
-                                        null,
-                                        arguments
-                                )
-                        ))
-                        .description(tool.description())
-                        .inputType(tool.inputType())
-                        .build());
-            }
-
-            toolContext.put("userId", userId);
-            builder.toolNames(allowedToolNames);
-            builder.toolCallbacks(toolCallbacks);
-            builder.toolContext(toolContext);
-        }
-
-        return builder.build();
+        return new Prompt(promptMessages, options);
     }
 
     private Message toSpringMessage(AiMessage message) {
@@ -210,6 +160,7 @@ public class SpringAiChatService implements AiChatService {
 
     private AiToolCall toToolCall(AssistantMessage.ToolCall toolCall) {
         return new AiToolCall(
+                toolCall.id(),
                 toolCall.name(),
                 parseArguments(toolCall.arguments())
         );
@@ -237,9 +188,10 @@ public class SpringAiChatService implements AiChatService {
             List<ToolResponseMessage.ToolResponse> responses = new ArrayList<>();
             for (Map<String, Object> item : payload) {
                 String toolName = String.valueOf(item.getOrDefault("toolName", "tool"));
+                String toolCallId = String.valueOf(item.getOrDefault("toolCallId", toolName));
                 Object result = item.get("result");
                 String serializedResult = objectMapper.writeValueAsString(result);
-                responses.add(new ToolResponseMessage.ToolResponse(toolName, toolName, serializedResult));
+                responses.add(new ToolResponseMessage.ToolResponse(toolCallId, toolName, serializedResult));
             }
             return ToolResponseMessage.builder()
                     .responses(responses)
@@ -248,10 +200,11 @@ public class SpringAiChatService implements AiChatService {
             try {
                 Map<String, Object> payload = objectMapper.readValue(content, Map.class);
                 String toolName = String.valueOf(payload.getOrDefault("toolName", "tool"));
+                String toolCallId = String.valueOf(payload.getOrDefault("toolCallId", toolName));
                 Object result = payload.get("result");
                 String serializedResult = objectMapper.writeValueAsString(result);
                 return ToolResponseMessage.builder()
-                        .responses(List.of(new ToolResponseMessage.ToolResponse(toolName, toolName, serializedResult)))
+                        .responses(List.of(new ToolResponseMessage.ToolResponse(toolCallId, toolName, serializedResult)))
                         .build();
             } catch (Exception ignored) {
                 return ToolResponseMessage.builder()

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingConfiguration.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingConfiguration.java
@@ -1,6 +1,5 @@
 package io.quintkard.quintkardapp.embedding;
 
-import io.quintkard.quintkardapp.aimodel.AiProvider;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingConfiguration.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingConfiguration.java
@@ -1,9 +1,44 @@
 package io.quintkard.quintkardapp.embedding;
 
+import io.quintkard.quintkardapp.aimodel.AiProvider;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
-@EnableConfigurationProperties(EmbeddingProperties.class)
+@EnableConfigurationProperties({
+        EmbeddingProperties.class,
+        EmbeddingProviderProperties.class
+})
 public class EmbeddingConfiguration {
+
+    @Bean
+    @Primary
+    EmbeddingModel embeddingModel(
+            EmbeddingProviderProperties properties,
+            @Qualifier("googleGenAiTextEmbedding") ObjectProvider<EmbeddingModel> googleEmbeddingProvider,
+            @Qualifier("openAiEmbeddingModel") ObjectProvider<EmbeddingModel> openAiEmbeddingProvider
+    ) {
+        return switch (properties.getProvider()) {
+            case GOOGLE_GENAI -> requireConfiguredEmbeddingModel(
+                    "Google GenAI",
+                    googleEmbeddingProvider.getIfAvailable()
+            );
+            case OPENAI -> requireConfiguredEmbeddingModel(
+                    "OpenAI",
+                    openAiEmbeddingProvider.getIfAvailable()
+            );
+        };
+    }
+
+    private EmbeddingModel requireConfiguredEmbeddingModel(String providerName, EmbeddingModel embeddingModel) {
+        if (embeddingModel == null) {
+            throw new IllegalStateException(providerName + " embedding model is not configured");
+        }
+        return embeddingModel;
+    }
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingProviderProperties.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingProviderProperties.java
@@ -1,0 +1,18 @@
+package io.quintkard.quintkardapp.embedding;
+
+import io.quintkard.quintkardapp.aimodel.AiProvider;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "quintkard.embedding.selection")
+public class EmbeddingProviderProperties {
+
+    private AiProvider provider = AiProvider.GOOGLE_GENAI;
+
+    public AiProvider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(AiProvider provider) {
+        this.provider = provider;
+    }
+}

--- a/quintkard-app/src/main/resources/application.properties
+++ b/quintkard-app/src/main/resources/application.properties
@@ -19,14 +19,11 @@ spring.datasource.hikari.connection-init-sql=CREATE EXTENSION IF NOT EXISTS vect
 spring.jpa.hibernate.ddl-auto=update
 
 # Embeddings
-# Vertex AI configuration (configure google application default credentials if using vertex AI)
 spring.ai.model.chat=google-genai
+spring.ai.model.embedding=google-genai
 spring.ai.model.embedding.text=google-genai
-# Gemini Developer API / AI Studio key configuration
-# spring.ai.google.genai.api-key=${GOOGLE_API_KEY:}
-# spring.ai.google.genai.embedding.api-key=${GOOGLE_API_KEY:}
 
-# Vertex AI configuration
+# Vertex AI configuration (configure google application default credentials if using vertex AI)
 spring.ai.google.genai.vertex-ai=true
 spring.ai.google.genai.project-id=bpk-poc-project
 spring.ai.google.genai.location=us-central1
@@ -36,7 +33,28 @@ spring.ai.google.genai.embedding.project-id=bpk-poc-project
 spring.ai.google.genai.embedding.location=us-central1
 spring.ai.google.genai.embedding.text.options.model=gemini-embedding-001
 
+# Gemini Developer API / AI Studio key configuration
+# spring.ai.google.genai.api-key=${GOOGLE_API_KEY:}
+# spring.ai.google.genai.embedding.api-key=${GOOGLE_API_KEY:}
+
+# OpenAI configuration
+spring.ai.model.audio.speech=none
+spring.ai.model.audio.transcription=none
+spring.ai.model.image=none
+spring.ai.model.moderation=none
+quintkard.ai.openai.api-key=${OPENAI_API_KEY:}
+spring.ai.openai.api-key=${OPENAI_API_KEY:}
+spring.ai.openai.base-url=https://api.openai.com
+spring.ai.openai.chat.options.model=gpt-5.4-mini
+
+quintkard.ai.models[gemini-2.5-flash].provider=GOOGLE_GENAI
+quintkard.ai.models[gpt-5.4-mini].provider=OPENAI
+quintkard.ai.models[gpt-5.4].provider=OPENAI
+quintkard.ai.models[gpt-5.2].provider=OPENAI
+quintkard.ai.models[gpt-5.1-codex-mini].provider=OPENAI
+
 quintkard.embedding.model=gemini-embedding-001
+quintkard.embedding.selection.provider=GOOGLE_GENAI
 quintkard.embedding.chunking-strategy=summary-and-content-v1
 quintkard.embedding.batch-size=16
 quintkard.embedding.dimensions=3072

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImplTest.java
@@ -83,7 +83,7 @@ class AgentLoopExecutorImplTest {
         when(aiChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "",
-                        List.of(new AiToolCall("get_current_time", Map.of("timezone", "UTC"))),
+                        List.of(new AiToolCall("call-1", "get_current_time", Map.of("timezone", "UTC"))),
                         false
                 ))
                 .thenReturn(new AiChatResponse("final answer", List.of(), true));
@@ -99,12 +99,14 @@ class AgentLoopExecutorImplTest {
         assertEquals(2, result.iterations());
         assertEquals(1, result.toolCalls());
         assertEquals(1, result.toolResults().size());
+        assertEquals("call-1", result.toolResults().getFirst().toolCallId());
 
         ArgumentCaptor<AiChatRequest> requestCaptor = ArgumentCaptor.forClass(AiChatRequest.class);
         verify(aiChatService, org.mockito.Mockito.times(2)).chat(requestCaptor.capture());
         AiChatRequest secondRequest = requestCaptor.getAllValues().get(1);
         assertEquals(1, secondRequest.messages().size());
         assertEquals(AiMessageRole.TOOL, secondRequest.messages().getFirst().role());
+        assertTrue(secondRequest.messages().getFirst().content().contains("\"toolCallId\":\"call-1\""));
         assertTrue(secondRequest.messages().getFirst().content().contains("\"toolName\":\"get_current_time\""));
         assertTrue(secondRequest.messages().getFirst().content().contains("\"currentTime\":\"2026-04-05T12:00:00Z\""));
     }
@@ -118,7 +120,7 @@ class AgentLoopExecutorImplTest {
         when(aiChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "",
-                        List.of(new AiToolCall("create_card", Map.of("title", "Follow up"))),
+                        List.of(new AiToolCall("call-2", "create_card", Map.of("title", "Follow up"))),
                         false
                 ))
                 .thenReturn(new AiChatResponse("recovered", List.of(), true));
@@ -148,8 +150,8 @@ class AgentLoopExecutorImplTest {
                 .thenReturn(new AiChatResponse(
                         "needs tools",
                         List.of(
-                                new AiToolCall("get_current_time", Map.of()),
-                                new AiToolCall("get_current_date", Map.of())
+                                new AiToolCall("call-1", "get_current_time", Map.of()),
+                                new AiToolCall("call-2", "get_current_date", Map.of())
                         ),
                         false
                 ));
@@ -173,7 +175,7 @@ class AgentLoopExecutorImplTest {
         when(aiChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "still working",
-                        List.of(new AiToolCall("get_current_time", Map.of())),
+                        List.of(new AiToolCall("call-1", "get_current_time", Map.of())),
                         false
                 ));
 
@@ -211,7 +213,7 @@ class AgentLoopExecutorImplTest {
         when(aiChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "",
-                        List.of(new AiToolCall("not_allowed_tool", Map.of("x", 1))),
+                        List.of(new AiToolCall("call-1", "not_allowed_tool", Map.of("x", 1))),
                         false
                 ))
                 .thenReturn(new AiChatResponse("handled missing tool", List.of(), true));
@@ -293,7 +295,7 @@ class AgentLoopExecutorImplTest {
         when(localChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "",
-                        List.of(new AiToolCall("get_current_time", Map.of("timezone", "UTC"))),
+                        List.of(new AiToolCall("call-1", "get_current_time", Map.of("timezone", "UTC"))),
                         false
                 ))
                 .thenReturn(new AiChatResponse("done", List.of(), true));
@@ -330,7 +332,7 @@ class AgentLoopExecutorImplTest {
         when(localChatService.chat(any(AiChatRequest.class)))
                 .thenReturn(new AiChatResponse(
                         "",
-                        List.of(new AiToolCall("get_current_time", Map.of("timezone", "UTC"))),
+                        List.of(new AiToolCall("call-1", "get_current_time", Map.of("timezone", "UTC"))),
                         false
                 ));
         doAnswer(invocation -> {

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/AiModelConfigurationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/AiModelConfigurationTest.java
@@ -1,0 +1,35 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class AiModelConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(AiModelConfiguration.class)
+            .withPropertyValues(
+                    "quintkard.ai.models[gemini-2.5-flash].provider=GOOGLE_GENAI",
+                    "quintkard.ai.models[gpt-5.4-mini].provider=OPENAI"
+            );
+
+    @Test
+    void registersSharedMemoryBeansAndBindsModelCatalog() {
+        contextRunner.run(context -> {
+            ChatMemoryRepository chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+            ChatMemory chatMemory = context.getBean(ChatMemory.class);
+            AiModelCatalogProperties catalogProperties = context.getBean(AiModelCatalogProperties.class);
+
+            assertNotNull(chatMemoryRepository);
+            assertNotNull(chatMemory);
+            assertEquals(AiProvider.GOOGLE_GENAI,
+                    catalogProperties.getModels().get("gemini-2.5-flash").provider());
+            assertEquals(AiProvider.OPENAI,
+                    catalogProperties.getModels().get("gpt-5.4-mini").provider());
+        });
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistryTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistryTest.java
@@ -1,0 +1,165 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.beans.factory.ObjectProvider;
+
+class DefaultAiChatModelRegistryTest {
+
+    private AiModelCatalogProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AiModelCatalogProperties();
+        properties.setModels(Map.of(
+                "gemini-2.5-flash", new AiModelDefinition(AiProvider.GOOGLE_GENAI),
+                "gpt-5.4-mini", new AiModelDefinition(AiProvider.OPENAI)
+        ));
+    }
+
+    @Test
+    void returnsGoogleModelForGoogleCatalogEntry() {
+        GoogleGenAiChatModel googleModel = mock(GoogleGenAiChatModel.class);
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                fixedProvider(googleModel),
+                emptyProvider()
+        );
+
+        assertEquals(AiProvider.GOOGLE_GENAI, registry.providerFor("gemini-2.5-flash"));
+        assertSame(googleModel, registry.get("gemini-2.5-flash"));
+    }
+
+    @Test
+    void returnsOpenAiModelForOpenAiCatalogEntry() {
+        OpenAiChatModel openAiChatModel = mock(OpenAiChatModel.class);
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                emptyProvider(),
+                fixedProvider(openAiChatModel)
+        );
+
+        assertEquals(AiProvider.OPENAI, registry.providerFor("gpt-5.4-mini"));
+        assertSame(openAiChatModel, registry.get("gpt-5.4-mini"));
+    }
+
+    @Test
+    void rejectsUnsupportedModel() {
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                emptyProvider(),
+                emptyProvider()
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.providerFor("unknown-model")
+        );
+
+        assertEquals("Unsupported AI model: unknown-model", exception.getMessage());
+    }
+
+    @Test
+    void rejectsNullOrBlankModelName() {
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                emptyProvider(),
+                emptyProvider()
+        );
+
+        IllegalArgumentException nullException = assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.providerFor(null)
+        );
+        assertEquals("AI model is required", nullException.getMessage());
+
+        IllegalArgumentException blankException = assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.providerFor("   ")
+        );
+        assertEquals("AI model is required", blankException.getMessage());
+    }
+
+    @Test
+    void rejectsConfiguredGoogleProviderWhenConcreteBeanMissing() {
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                emptyProvider(),
+                emptyProvider()
+        );
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> registry.get("gemini-2.5-flash")
+        );
+
+        assertEquals(
+                "Google GenAI chat model is not configured for requested model gemini-2.5-flash",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void rejectsConfiguredProviderWhenConcreteBeanMissing() {
+        DefaultAiChatModelRegistry registry = new DefaultAiChatModelRegistry(
+                properties,
+                emptyProvider(),
+                emptyProvider()
+        );
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> registry.get("gpt-5.4-mini")
+        );
+
+        assertEquals(
+                "OpenAI chat model is not configured for requested model gpt-5.4-mini",
+                exception.getMessage()
+        );
+    }
+
+    private <T> ObjectProvider<T> fixedProvider(T value) {
+        return new SimpleObjectProvider<>(value);
+    }
+
+    private <T> ObjectProvider<T> emptyProvider() {
+        return new SimpleObjectProvider<>(null);
+    }
+
+    private static final class SimpleObjectProvider<T> implements ObjectProvider<T> {
+
+        private final T value;
+
+        private SimpleObjectProvider(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T getObject(Object... args) {
+            return value;
+        }
+
+        @Override
+        public T getIfAvailable() {
+            return value;
+        }
+
+        @Override
+        public T getIfUnique() {
+            return value;
+        }
+
+        @Override
+        public T getObject() {
+            return value;
+        }
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistryTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistryTest.java
@@ -154,7 +154,7 @@ class DefaultAiChatModelRegistryTest {
 
         @Override
         public T getIfUnique() {
-            return value;
+            return getIfAvailable();
         }
 
         @Override

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactoryTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactoryTest.java
@@ -1,0 +1,176 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.quintkard.quintkardapp.agenttool.AiTool;
+import io.quintkard.quintkardapp.agenttool.AiToolExecutionRequest;
+import io.quintkard.quintkardapp.agenttool.AiToolScopeResolver;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+class DefaultAiChatOptionsFactoryTest {
+
+    private AiToolScopeResolver toolScopeResolver;
+    private DefaultAiChatOptionsFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        toolScopeResolver = mock(AiToolScopeResolver.class);
+        factory = new DefaultAiChatOptionsFactory(toolScopeResolver);
+    }
+
+    @Test
+    void buildsGoogleOptionsWithStructuredOutputAndTools() {
+        AiTool tool = mock(AiTool.class);
+        when(tool.name()).thenReturn("get_current_time");
+        when(tool.description()).thenReturn("Gets current time");
+        doReturn(Map.class).when(tool).inputType();
+        when(tool.execute(new AiToolExecutionRequest("admin", null, Map.of("timeZone", "UTC"))))
+                .thenReturn(Map.of("timeZone", "UTC"));
+        when(toolScopeResolver.resolveTools("admin", Set.of("get_current_time"))).thenReturn(List.of(tool));
+
+        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) factory.build(
+                AiProvider.GOOGLE_GENAI,
+                "admin",
+                "gemini-2.5-flash",
+                0.3,
+                new AiToolScope(Set.of("get_current_time")),
+                "{\"type\":\"object\"}",
+                "application/json"
+        );
+
+        assertEquals("gemini-2.5-flash", options.getModel());
+        assertEquals(0.3, options.getTemperature());
+        assertEquals(false, options.getInternalToolExecutionEnabled());
+        assertEquals("{\"type\":\"object\"}", options.getResponseSchema());
+        assertEquals("application/json", options.getResponseMimeType());
+        assertEquals("admin", options.getLabels().get("userId"));
+        assertEquals(Set.of("get_current_time"), options.getToolNames());
+        assertEquals("admin", options.getToolContext().get("userId"));
+        assertEquals(1, options.getToolCallbacks().size());
+        assertEquals(
+                "{\"timeZone\":\"UTC\"}",
+                options.getToolCallbacks().getFirst().call("{\"timeZone\":\"UTC\"}")
+        );
+        verify(tool).execute(new AiToolExecutionRequest("admin", null, Map.of("timeZone", "UTC")));
+    }
+
+    @Test
+    void buildsOpenAiOptionsWithStructuredOutputAndTools() {
+        AiTool tool = mock(AiTool.class);
+        when(tool.name()).thenReturn("get_current_time");
+        when(tool.description()).thenReturn("Gets current time");
+        doReturn(Map.class).when(tool).inputType();
+        when(tool.execute(new AiToolExecutionRequest("admin", null, Map.of("timeZone", "UTC"))))
+                .thenReturn(Map.of("timeZone", "UTC"));
+        when(toolScopeResolver.resolveTools("admin", Set.of("get_current_time"))).thenReturn(List.of(tool));
+
+        OpenAiChatOptions options = (OpenAiChatOptions) factory.build(
+                AiProvider.OPENAI,
+                "admin",
+                "gpt-5.4-mini",
+                0.4,
+                new AiToolScope(Set.of("get_current_time")),
+                "{\"type\":\"object\"}",
+                "application/json"
+        );
+
+        assertEquals("gpt-5.4-mini", options.getModel());
+        assertEquals(0.4, options.getTemperature());
+        assertEquals(false, options.getInternalToolExecutionEnabled());
+        assertEquals("{\"type\":\"object\"}", options.getOutputSchema());
+        assertEquals("admin", options.getUser());
+        assertNull(options.getMetadata());
+        assertEquals(Set.of("get_current_time"), options.getToolNames());
+        assertEquals("admin", options.getToolContext().get("userId"));
+        assertEquals(1, options.getToolCallbacks().size());
+        assertEquals(
+                "{\"timeZone\":\"UTC\"}",
+                options.getToolCallbacks().getFirst().call("{\"timeZone\":\"UTC\"}")
+        );
+        verify(tool).execute(new AiToolExecutionRequest("admin", null, Map.of("timeZone", "UTC")));
+    }
+
+    @Test
+    void skipsToolResolutionWhenToolScopeMissing() {
+        OpenAiChatOptions options = (OpenAiChatOptions) factory.build(
+                AiProvider.OPENAI,
+                "admin",
+                "gpt-5.4-mini",
+                0.2,
+                null,
+                null,
+                null
+        );
+
+        assertEquals(Set.of(), options.getToolNames());
+        assertEquals(List.of(), options.getToolCallbacks());
+        assertEquals(Map.of(), options.getToolContext());
+    }
+
+    @Test
+    void skipsToolResolutionWhenAllowedToolNamesAreNull() {
+        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) factory.build(
+                AiProvider.GOOGLE_GENAI,
+                "admin",
+                "gemini-2.5-flash",
+                0.2,
+                new AiToolScope(null),
+                null,
+                null
+        );
+
+        assertEquals(Map.of("userId", "admin"), options.getLabels());
+        assertEquals(Set.of(), options.getToolNames());
+        assertEquals(List.of(), options.getToolCallbacks());
+        assertEquals(Map.of(), options.getToolContext());
+    }
+
+    @Test
+    void skipsToolResolutionWhenAllowedToolNamesAreEmpty() {
+        OpenAiChatOptions options = (OpenAiChatOptions) factory.build(
+                AiProvider.OPENAI,
+                "admin",
+                "gpt-5.4-mini",
+                0.2,
+                new AiToolScope(Set.of()),
+                null,
+                null
+        );
+
+        assertEquals(Set.of(), options.getToolNames());
+        assertEquals(List.of(), options.getToolCallbacks());
+        assertEquals(Map.of(), options.getToolContext());
+        assertNull(options.getOutputSchema());
+    }
+
+    @Test
+    void buildsGoogleOptionsWithoutStructuredOutputWhenSchemaAndMimeTypeAreAbsent() {
+        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) factory.build(
+                AiProvider.GOOGLE_GENAI,
+                "admin",
+                "gemini-2.5-flash",
+                0.2,
+                null,
+                null,
+                null
+        );
+
+        assertEquals("gemini-2.5-flash", options.getModel());
+        assertEquals(0.2, options.getTemperature());
+        assertEquals(false, options.getInternalToolExecutionEnabled());
+        assertEquals(Map.of("userId", "admin"), options.getLabels());
+        assertNull(options.getResponseSchema());
+        assertNull(options.getResponseMimeType());
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiChatServiceTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiChatServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiChatServiceTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiChatServiceTest.java
@@ -3,22 +3,17 @@ package io.quintkard.quintkardapp.aimodel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.quintkard.quintkardapp.agenttool.AiTool;
-import io.quintkard.quintkardapp.agenttool.AiToolExecutionRequest;
-import io.quintkard.quintkardapp.agenttool.AiToolScopeResolver;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,15 +28,17 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import tools.jackson.databind.ObjectMapper;
 
 class SpringAiChatServiceTest {
 
     private ChatMemory chatMemory;
     private ChatModel chatModel;
-    private AiToolScopeResolver toolScopeResolver;
+    private AiChatModelRegistry chatModelRegistry;
+    private AiChatOptionsFactory chatOptionsFactory;
+    private ChatOptions chatOptions;
     private SpringAiChatService service;
 
     @BeforeEach
@@ -51,8 +48,44 @@ class SpringAiChatServiceTest {
                 .maxMessages(100)
                 .build();
         chatModel = mock(ChatModel.class);
-        toolScopeResolver = mock(AiToolScopeResolver.class);
-        service = new SpringAiChatService(chatMemory, chatModel, toolScopeResolver, new ObjectMapper());
+        chatModelRegistry = mock(AiChatModelRegistry.class);
+        chatOptionsFactory = mock(AiChatOptionsFactory.class);
+        chatOptions = mock(ChatOptions.class);
+        when(chatModelRegistry.get("gemini-2.5-flash")).thenReturn(chatModel);
+        when(chatModelRegistry.providerFor("gemini-2.5-flash")).thenReturn(AiProvider.GOOGLE_GENAI);
+        when(chatOptionsFactory.build(any(), any(), any(), any(Double.class), any(), any(), any()))
+                .thenReturn(chatOptions);
+        service = new SpringAiChatService(chatMemory, chatModelRegistry, chatOptionsFactory, new ObjectMapper());
+    }
+
+    @Test
+    void chatUsesOpenAiModelWhenCatalogResolvesOpenAiProvider() {
+        ChatModel openAiChatModel = mock(ChatModel.class);
+        when(chatModelRegistry.get("gpt-5.4-mini")).thenReturn(openAiChatModel);
+        when(chatModelRegistry.providerFor("gpt-5.4-mini")).thenReturn(AiProvider.OPENAI);
+        when(openAiChatModel.call(any(Prompt.class)))
+                .thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("openai-done")))));
+
+        AiChatResponse response = service.chat(new AiChatRequest(
+                "admin",
+                "gpt-5.4-mini",
+                0.2,
+                List.of(new AiMessage(AiMessageRole.USER, "hello")),
+                null,
+                null
+        ));
+
+        assertEquals("openai-done", response.text());
+        verify(openAiChatModel).call(any(Prompt.class));
+        verify(chatOptionsFactory).build(
+                AiProvider.OPENAI,
+                "admin",
+                "gpt-5.4-mini",
+                0.2,
+                null,
+                null,
+                null
+        );
     }
 
     @Test
@@ -85,6 +118,7 @@ class SpringAiChatServiceTest {
         assertEquals("previous user message", prompt.getInstructions().get(0).getText());
         assertEquals("system prompt", prompt.getInstructions().get(1).getText());
         assertEquals("new user message", prompt.getInstructions().get(2).getText());
+        assertEquals(chatOptions, prompt.getOptions());
 
         List<Message> memoryMessages = chatMemory.get(memoryScope.conversationId());
         assertEquals(3, memoryMessages.size());
@@ -98,12 +132,7 @@ class SpringAiChatServiceTest {
     }
 
     @Test
-    void chatExposesToolCallsAndBuildsToolOptions() {
-        AiTool tool = mock(AiTool.class);
-        when(tool.name()).thenReturn("get_current_time");
-        when(tool.description()).thenReturn("Gets current time");
-        doReturn(Map.class).when(tool).inputType();
-        when(toolScopeResolver.resolveTools("admin", Set.of("get_current_time"))).thenReturn(List.of(tool));
+    void chatExposesToolCalls() {
         AssistantMessage assistantMessage = AssistantMessage.builder()
                 .content("")
                 .toolCalls(List.of(new AssistantMessage.ToolCall("1", "function", "get_current_time", "{\"timeZone\":\"UTC\"}")))
@@ -117,25 +146,24 @@ class SpringAiChatServiceTest {
                 0.3,
                 List.of(new AiMessage(AiMessageRole.USER, "what time is it?")),
                 null,
-                new AiToolScope(Set.of("get_current_time"))
+                new AiToolScope(java.util.Set.of("get_current_time"))
         ));
 
         assertFalse(response.finalResponse());
         assertEquals(1, response.toolCalls().size());
+        assertEquals("1", response.toolCalls().getFirst().toolCallId());
         assertEquals("get_current_time", response.toolCalls().getFirst().toolName());
         assertEquals("UTC", response.toolCalls().getFirst().arguments().get("timeZone"));
 
-        ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-        verify(chatModel).call(promptCaptor.capture());
-        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) promptCaptor.getValue().getOptions();
-        assertEquals("gemini-2.5-flash", options.getModel());
-        assertEquals(0.3, options.getTemperature());
-        assertEquals(Set.of("get_current_time"), options.getToolNames());
-        assertEquals(false, options.getInternalToolExecutionEnabled());
-        assertEquals("admin", options.getLabels().get("userId"));
-        assertEquals("admin", options.getToolContext().get("userId"));
-        assertEquals(1, options.getToolCallbacks().size());
-        assertEquals("get_current_time", options.getToolCallbacks().getFirst().getToolDefinition().name());
+        verify(chatOptionsFactory).build(
+                AiProvider.GOOGLE_GENAI,
+                "admin",
+                "gemini-2.5-flash",
+                0.3,
+                new AiToolScope(java.util.Set.of("get_current_time")),
+                null,
+                null
+        );
     }
 
     @Test
@@ -190,9 +218,15 @@ class SpringAiChatServiceTest {
         assertInstanceOf(SystemMessage.class, prompt.getInstructions().getFirst());
         assertTrue(prompt.getInstructions().getFirst().getText().startsWith("Route carefully"));
         assertTrue(prompt.getInstructions().getFirst().getText().contains("JSON Schema"));
-        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) prompt.getOptions();
-        assertNotNull(options.getResponseSchema());
-        assertEquals("application/json", options.getResponseMimeType());
+        verify(chatOptionsFactory).build(
+                eq(AiProvider.GOOGLE_GENAI),
+                eq("admin"),
+                eq("gemini-2.5-flash"),
+                eq(0.1),
+                eq(null),
+                anyString(),
+                eq("application/json")
+        );
     }
 
     @Test
@@ -243,6 +277,7 @@ class SpringAiChatServiceTest {
         ToolResponseMessage responseMessage = (ToolResponseMessage) toolMessage;
         assertEquals(2, responseMessage.getResponses().size());
         assertEquals("tool_a", responseMessage.getResponses().get(0).name());
+        assertEquals("tool_a", responseMessage.getResponses().get(0).id());
         assertEquals("{\"ok\":true}", responseMessage.getResponses().get(0).responseData());
         assertEquals("\"text\"", responseMessage.getResponses().get(1).responseData());
     }
@@ -256,7 +291,7 @@ class SpringAiChatServiceTest {
                 "admin",
                 "gemini-2.5-flash",
                 0.2,
-                List.of(new AiMessage(AiMessageRole.TOOL, "{\"toolName\":\"tool_a\",\"result\":{\"ok\":true}}")),
+                List.of(new AiMessage(AiMessageRole.TOOL, "{\"toolCallId\":\"call-1\",\"toolName\":\"tool_a\",\"result\":{\"ok\":true}}")),
                 null,
                 null
         ));
@@ -266,6 +301,7 @@ class SpringAiChatServiceTest {
         ToolResponseMessage mapResponse = (ToolResponseMessage) promptCaptor.getValue().getInstructions().getFirst();
         assertEquals(1, mapResponse.getResponses().size());
         assertEquals("tool_a", mapResponse.getResponses().getFirst().name());
+        assertEquals("call-1", mapResponse.getResponses().getFirst().id());
 
         when(chatModel.call(any(Prompt.class)))
                 .thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("done")))));
@@ -285,34 +321,6 @@ class SpringAiChatServiceTest {
                 (ToolResponseMessage) secondCaptor.getAllValues().getLast().getInstructions().getFirst();
         assertEquals("tool", rawResponse.getResponses().getFirst().name());
         assertEquals("unstructured tool output", rawResponse.getResponses().getFirst().responseData());
-    }
-
-    @Test
-    void toolCallbackExecutesThroughResolver() {
-        AiTool tool = mock(AiTool.class);
-        when(tool.name()).thenReturn("get_current_time");
-        when(tool.description()).thenReturn("Gets current time");
-        doReturn(Map.class).when(tool).inputType();
-        when(tool.execute(any(AiToolExecutionRequest.class))).thenReturn(Map.of("timeZone", "UTC"));
-        when(toolScopeResolver.resolveTools("admin", Set.of("get_current_time"))).thenReturn(List.of(tool));
-        when(chatModel.call(any(Prompt.class)))
-                .thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("done")))));
-
-        service.chat(new AiChatRequest(
-                "admin",
-                "gemini-2.5-flash",
-                0.2,
-                List.of(new AiMessage(AiMessageRole.USER, "time")),
-                null,
-                new AiToolScope(Set.of("get_current_time"))
-        ));
-
-        ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-        verify(chatModel).call(promptCaptor.capture());
-        GoogleGenAiChatOptions options = (GoogleGenAiChatOptions) promptCaptor.getValue().getOptions();
-        String callbackResult = options.getToolCallbacks().getFirst().call("{\"timeZone\":\"UTC\"}");
-        assertTrue(callbackResult.contains("\"timeZone\":\"UTC\""));
-        verify(tool).execute(eq(new AiToolExecutionRequest("admin", null, Map.of("timeZone", "UTC"))));
     }
 
     private record RoutingLikeResponse(boolean accepted, String reason) {

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiMemoryServiceTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/aimodel/SpringAiMemoryServiceTest.java
@@ -1,0 +1,49 @@
+package io.quintkard.quintkardapp.aimodel;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+
+class SpringAiMemoryServiceTest {
+
+    private ChatMemoryRepository chatMemoryRepository;
+    private SpringAiMemoryService springAiMemoryService;
+
+    @BeforeEach
+    void setUp() {
+        chatMemoryRepository = mock(ChatMemoryRepository.class);
+        springAiMemoryService = new SpringAiMemoryService(chatMemoryRepository);
+    }
+
+    @Test
+    void ignoresNullMemoryScope() {
+        springAiMemoryService.clear(null);
+
+        verifyNoInteractions(chatMemoryRepository);
+    }
+
+    @Test
+    void ignoresNullConversationId() {
+        springAiMemoryService.clear(new AiMemoryScope(null));
+
+        verifyNoInteractions(chatMemoryRepository);
+    }
+
+    @Test
+    void ignoresBlankConversationId() {
+        springAiMemoryService.clear(new AiMemoryScope("   "));
+
+        verifyNoInteractions(chatMemoryRepository);
+    }
+
+    @Test
+    void deletesConversationWhenConversationIdIsPresent() {
+        springAiMemoryService.clear(new AiMemoryScope("msg:1:run:1"));
+
+        verify(chatMemoryRepository).deleteByConversationId("msg:1:run:1");
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/embedding/EmbeddingConfigurationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/embedding/EmbeddingConfigurationTest.java
@@ -47,10 +47,12 @@ class EmbeddingConfigurationTest {
     void failsWhenConfiguredEmbeddingProviderIsMissing() {
         EmbeddingProviderProperties properties = new EmbeddingProviderProperties();
         properties.setProvider(AiProvider.GOOGLE_GENAI);
+        ObjectProvider<EmbeddingModel> googleProvider = emptyProvider();
+        ObjectProvider<EmbeddingModel> openAiProvider = emptyProvider();
 
         IllegalStateException exception = assertThrows(
                 IllegalStateException.class,
-                () -> configuration.embeddingModel(properties, emptyProvider(), emptyProvider())
+                () -> configuration.embeddingModel(properties, googleProvider, openAiProvider)
         );
 
         org.junit.jupiter.api.Assertions.assertEquals(
@@ -87,7 +89,7 @@ class EmbeddingConfigurationTest {
 
         @Override
         public T getIfUnique() {
-            return value;
+            return getIfAvailable();
         }
 
         @Override

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/embedding/EmbeddingConfigurationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/embedding/EmbeddingConfigurationTest.java
@@ -1,0 +1,98 @@
+package io.quintkard.quintkardapp.embedding;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import io.quintkard.quintkardapp.aimodel.AiProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.beans.factory.ObjectProvider;
+
+class EmbeddingConfigurationTest {
+
+    private final EmbeddingConfiguration configuration = new EmbeddingConfiguration();
+
+    @Test
+    void selectsGoogleEmbeddingModelWhenConfigured() {
+        EmbeddingProviderProperties properties = new EmbeddingProviderProperties();
+        properties.setProvider(AiProvider.GOOGLE_GENAI);
+        EmbeddingModel googleEmbeddingModel = mock(EmbeddingModel.class);
+
+        EmbeddingModel selected = configuration.embeddingModel(
+                properties,
+                fixedProvider(googleEmbeddingModel),
+                emptyProvider()
+        );
+
+        assertSame(googleEmbeddingModel, selected);
+    }
+
+    @Test
+    void selectsOpenAiEmbeddingModelWhenConfigured() {
+        EmbeddingProviderProperties properties = new EmbeddingProviderProperties();
+        properties.setProvider(AiProvider.OPENAI);
+        EmbeddingModel openAiEmbeddingModel = mock(EmbeddingModel.class);
+
+        EmbeddingModel selected = configuration.embeddingModel(
+                properties,
+                emptyProvider(),
+                fixedProvider(openAiEmbeddingModel)
+        );
+
+        assertSame(openAiEmbeddingModel, selected);
+    }
+
+    @Test
+    void failsWhenConfiguredEmbeddingProviderIsMissing() {
+        EmbeddingProviderProperties properties = new EmbeddingProviderProperties();
+        properties.setProvider(AiProvider.GOOGLE_GENAI);
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> configuration.embeddingModel(properties, emptyProvider(), emptyProvider())
+        );
+
+        org.junit.jupiter.api.Assertions.assertEquals(
+                "Google GenAI embedding model is not configured",
+                exception.getMessage()
+        );
+    }
+
+    private <T> ObjectProvider<T> fixedProvider(T value) {
+        return new SimpleObjectProvider<>(value);
+    }
+
+    private <T> ObjectProvider<T> emptyProvider() {
+        return new SimpleObjectProvider<>(null);
+    }
+
+    private static final class SimpleObjectProvider<T> implements ObjectProvider<T> {
+
+        private final T value;
+
+        private SimpleObjectProvider(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T getObject(Object... args) {
+            return value;
+        }
+
+        @Override
+        public T getIfAvailable() {
+            return value;
+        }
+
+        @Override
+        public T getIfUnique() {
+            return value;
+        }
+
+        @Override
+        public T getObject() {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds real multi-provider chat support to the backend AI model layer while keeping embeddings pinned to a single configured provider.

## Changes

- add provider-aware AI model catalog and registry
- add provider-specific chat options factory for Gemini and OpenAI
- refactor  to resolve chat model and options per request
- support OpenAI chat alongside the existing Google GenAI path
- keep embeddings single-provider via app-level embedding selection
- preserve tool call IDs through the agent loop for OpenAI compatibility
- add focused tests for registry, options factory, config, embedding selection, memory service, and tool-call correlation

## Notes

- Google remains the default chat and embedding provider in local config
- OpenAI chat is available when  is provided
- OpenAI audio/image/moderation/transcription are explicitly disabled in app properties
- JaCoCo was regenerated after the coverage additions
