### PR TITLE
Externalize CORS and message queue settings

### DIFF
--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/MessageQueueConfig.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/MessageQueueConfig.java
@@ -1,22 +1,24 @@
 package io.quintkard.quintkardapp.config;
 
 import io.quintkard.quintkardapp.logging.MdcTaskDecorator;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
+@EnableConfigurationProperties(MessageQueueProperties.class)
 public class MessageQueueConfig {
 
     @Bean(name = "messageQueueTaskExecutor")
-    ThreadPoolTaskExecutor messageQueueTaskExecutor() {
+    ThreadPoolTaskExecutor messageQueueTaskExecutor(MessageQueueProperties messageQueueProperties) {
         ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
-        taskExecutor.setCorePoolSize(1);
-        taskExecutor.setMaxPoolSize(1);
-        taskExecutor.setQueueCapacity(1);
+        taskExecutor.setCorePoolSize(messageQueueProperties.getCorePoolSize());
+        taskExecutor.setMaxPoolSize(messageQueueProperties.getMaxPoolSize());
+        taskExecutor.setQueueCapacity(messageQueueProperties.getQueueCapacity());
         taskExecutor.setThreadNamePrefix("message-queue-");
         taskExecutor.setWaitForTasksToCompleteOnShutdown(true);
-        taskExecutor.setAwaitTerminationSeconds(30);
+        taskExecutor.setAwaitTerminationSeconds(messageQueueProperties.getAwaitTerminationSeconds());
         taskExecutor.setTaskDecorator(new MdcTaskDecorator());
         taskExecutor.initialize();
         return taskExecutor;

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/MessageQueueProperties.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/MessageQueueProperties.java
@@ -1,0 +1,71 @@
+package io.quintkard.quintkardapp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "quintkard.message.queue")
+public class MessageQueueProperties {
+
+    private boolean enabled = true;
+    private int batchSize = 10;
+    private long pollDelayMs = 5000;
+    private int corePoolSize = 1;
+    private int maxPoolSize = 1;
+    private int queueCapacity = 1;
+    private int awaitTerminationSeconds = 30;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public long getPollDelayMs() {
+        return pollDelayMs;
+    }
+
+    public void setPollDelayMs(long pollDelayMs) {
+        this.pollDelayMs = pollDelayMs;
+    }
+
+    public int getCorePoolSize() {
+        return corePoolSize;
+    }
+
+    public void setCorePoolSize(int corePoolSize) {
+        this.corePoolSize = corePoolSize;
+    }
+
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public void setMaxPoolSize(int maxPoolSize) {
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getQueueCapacity() {
+        return queueCapacity;
+    }
+
+    public void setQueueCapacity(int queueCapacity) {
+        this.queueCapacity = queueCapacity;
+    }
+
+    public int getAwaitTerminationSeconds() {
+        return awaitTerminationSeconds;
+    }
+
+    public void setAwaitTerminationSeconds(int awaitTerminationSeconds) {
+        this.awaitTerminationSeconds = awaitTerminationSeconds;
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package io.quintkard.quintkardapp.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,6 +16,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
+@EnableConfigurationProperties(SecurityCorsProperties.class)
 public class SecurityConfig {
 
     @Bean
@@ -33,9 +35,9 @@ public class SecurityConfig {
     }
 
     @Bean
-    CorsConfigurationSource corsConfigurationSource() {
+    CorsConfigurationSource corsConfigurationSource(SecurityCorsProperties securityCorsProperties) {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(securityCorsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setExposedHeaders(List.of("WWW-Authenticate"));

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityCorsProperties.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityCorsProperties.java
@@ -1,0 +1,19 @@
+package io.quintkard.quintkardapp.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "quintkard.security.cors")
+public class SecurityCorsProperties {
+
+    private List<String> allowedOrigins = List.of("http://localhost:3000");
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.messagepipeline;
 
+import io.quintkard.quintkardapp.config.MessageQueueProperties;
 import io.quintkard.quintkardapp.logging.LogContext;
 import io.quintkard.quintkardapp.message.Message;
 import io.quintkard.quintkardapp.message.MessageRepository;
@@ -7,7 +8,6 @@ import io.quintkard.quintkardapp.message.MessageStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -40,9 +40,9 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
         MessageProcessor messageProcessor,
         PlatformTransactionManager transactionManager,
         @Qualifier("messageQueueTaskExecutor") ThreadPoolTaskExecutor taskExecutor,
-        @Value("${quintkard.message.queue.batch-size:10}") int batchSize
+        MessageQueueProperties messageQueueProperties
     ) {
-        this.batchSize = batchSize;
+        this.batchSize = messageQueueProperties.getBatchSize();
         this.messageProcessor = messageProcessor;
         this.messageRepository = messageRepository;
         this.taskExecutor = taskExecutor;

--- a/quintkard-app/src/main/resources/application.properties
+++ b/quintkard-app/src/main/resources/application.properties
@@ -44,8 +44,17 @@ quintkard.embedding.max-semantic-distance=0.45
 quintkard.agent.execution.max-iterations=30
 quintkard.agent.execution.max-tool-calls=100
 
+# Security
+quintkard.security.cors.allowed-origins=http://localhost:3000
+
 # Message queue
 quintkard.message.queue.enabled=true
+quintkard.message.queue.batch-size=10
+quintkard.message.queue.poll-delay-ms=5000
+quintkard.message.queue.core-pool-size=1
+quintkard.message.queue.max-pool-size=1
+quintkard.message.queue.queue-capacity=1
+quintkard.message.queue.await-termination-seconds=30
 
 # Exclude autoconfiguration
 spring.autoconfigure.exclude=org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueServiceTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.quintkard.quintkardapp.config.MessageQueueProperties;
 import io.quintkard.quintkardapp.message.Message;
 import io.quintkard.quintkardapp.message.MessageRepository;
 import io.quintkard.quintkardapp.message.MessageStatus;
@@ -48,7 +49,7 @@ class DatabaseBackedMessageQueueServiceTest {
                 messageProcessor,
                 transactionManager(),
                 taskExecutor,
-                10
+                messageQueueProperties()
         );
     }
 
@@ -178,6 +179,12 @@ class DatabaseBackedMessageQueueServiceTest {
         TransactionStatus transactionStatus = new SimpleTransactionStatus();
         when(transactionManager.getTransaction(any(TransactionDefinition.class))).thenReturn(transactionStatus);
         return transactionManager;
+    }
+
+    private MessageQueueProperties messageQueueProperties() {
+        MessageQueueProperties properties = new MessageQueueProperties();
+        properties.setBatchSize(10);
+        return properties;
     }
 
     private Message message() {


### PR DESCRIPTION
## Summary

This PR moves the selected environment-sensitive settings out of hardcoded config and into application properties.

## Changes

- externalize CORS allowed origins
- externalize message queue batch size and poll delay
- externalize message queue executor sizing and shutdown timing
- add typed configuration properties for CORS and message queue settings
- update queue service test for the new properties-based constructor

## Notes

- security policy defaults such as allowed methods, headers, exposed headers, and allowCredentials remain in code
- only the requested maintainability-focused settings were exported
