### PR TITLE
Improve card and message filtering

### DIFF
--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/HybridSearchCardsTool.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/HybridSearchCardsTool.java
@@ -1,6 +1,7 @@
 package io.quintkard.quintkardapp.agenttool;
 
 import io.quintkard.quintkardapp.card.CardService;
+import io.quintkard.quintkardapp.card.CardFilter;
 import io.quintkard.quintkardapp.card.CardSummaryProjection;
 import io.quintkard.quintkardapp.card.CardSliceResponse;
 import org.springframework.data.domain.Slice;
@@ -37,14 +38,16 @@ public class HybridSearchCardsTool extends AbstractCardAiTool {
         }
 
         Slice<CardSummaryProjection> cards = cardService.listCards(
-                request.userId(),
+                new CardFilter(
+                        request.userId(),
+                        arguments.query(),
+                        parseCardStatus(arguments.status(), false),
+                        null,
+                        null,
+                        null
+                ),
                 0,
-                normalizeLimit(arguments.limit()),
-                arguments.query(),
-                parseCardStatus(arguments.status(), false),
-                null,
-                null,
-                null
+                normalizeLimit(arguments.limit())
         );
         return CardSliceResponse.from(cards);
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/HybridSearchCardsTool.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/HybridSearchCardsTool.java
@@ -41,7 +41,10 @@ public class HybridSearchCardsTool extends AbstractCardAiTool {
                 0,
                 normalizeLimit(arguments.limit()),
                 arguments.query(),
-                parseCardStatus(arguments.status(), false)
+                parseCardStatus(arguments.status(), false),
+                null,
+                null,
+                null
         );
         return CardSliceResponse.from(cards);
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardController.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardController.java
@@ -73,16 +73,15 @@ public class CardController {
             @RequestParam(required = false) Instant updatedAfter,
             @RequestParam(required = false) Instant updatedBefore
     ) {
-        Slice<CardSummaryProjection> cards = cardService.listCards(
+        CardFilter filter = new CardFilter(
                 authentication.getName(),
-                page,
-                size,
                 query,
                 status,
                 cardType,
                 updatedAfter,
                 updatedBefore
         );
+        Slice<CardSummaryProjection> cards = cardService.listCards(filter, page, size);
         return CardSliceResponse.from(cards);
     }
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardController.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardController.java
@@ -1,6 +1,7 @@
 package io.quintkard.quintkardapp.card;
 
 import jakarta.validation.Valid;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -67,14 +68,20 @@ public class CardController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String query,
-            @RequestParam(required = false) CardStatus status
+            @RequestParam(required = false) CardStatus status,
+            @RequestParam(required = false) CardType cardType,
+            @RequestParam(required = false) Instant updatedAfter,
+            @RequestParam(required = false) Instant updatedBefore
     ) {
         Slice<CardSummaryProjection> cards = cardService.listCards(
                 authentication.getName(),
                 page,
                 size,
                 query,
-                status
+                status,
+                cardType,
+                updatedAfter,
+                updatedBefore
         );
         return CardSliceResponse.from(cards);
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardFilter.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardFilter.java
@@ -1,0 +1,13 @@
+package io.quintkard.quintkardapp.card;
+
+import java.time.Instant;
+
+public record CardFilter(
+        String userId,
+        String query,
+        CardStatus status,
+        CardType cardType,
+        Instant updatedAfter,
+        Instant updatedBefore
+) {
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.card;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -28,35 +29,18 @@ public interface CardRepository extends JpaRepository<Card, UUID>, CardSearchRep
         from Card c
         join c.user u
         where u.userId = :userId
+          and (:status is null or c.status = :status)
+          and (:cardType is null or c.cardType = :cardType)
+          and c.updatedAt >= coalesce(:updatedAfter, c.updatedAt)
+          and c.updatedAt <= coalesce(:updatedBefore, c.updatedAt)
         order by c.updatedAt desc
         """)
-    Slice<CardSummaryProjection> findSummariesByUserUserIdOrderByUpdatedAtDesc(
-            @Param("userId") String userId,
-            Pageable pageable
-    );
-
-    @Query("""
-        select
-            c.id as id,
-            u.userId as userId,
-            c.title as title,
-            c.summary as summary,
-            c.cardType as cardType,
-            c.status as status,
-            c.priority as priority,
-            c.dueDate as dueDate,
-            c.sourceMessageId as sourceMessageId,
-            c.createdAt as createdAt,
-            c.updatedAt as updatedAt
-        from Card c
-        join c.user u
-        where u.userId = :userId
-          and c.status = :status
-        order by c.updatedAt desc
-        """)
-    Slice<CardSummaryProjection> findSummariesByUserUserIdAndStatusOrderByUpdatedAtDesc(
+    Slice<CardSummaryProjection> findSummariesByFiltersOrderByUpdatedAtDesc(
             @Param("userId") String userId,
             @Param("status") CardStatus status,
+            @Param("cardType") CardType cardType,
+            @Param("updatedAfter") Instant updatedAfter,
+            @Param("updatedBefore") Instant updatedBefore,
             Pageable pageable
     );
 

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
@@ -1,47 +1,11 @@
 package io.quintkard.quintkardapp.card;
 
-import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface CardRepository extends JpaRepository<Card, UUID>, CardSearchRepository {
+public interface CardRepository extends JpaRepository<Card, UUID>, JpaSpecificationExecutor<Card>, CardSearchRepository {
 
     Optional<Card> findByIdAndUser_UserId(UUID id, String userId);
-
-    @Query("""
-        select
-            c.id as id,
-            u.userId as userId,
-            c.title as title,
-            c.summary as summary,
-            c.cardType as cardType,
-            c.status as status,
-            c.priority as priority,
-            c.dueDate as dueDate,
-            c.sourceMessageId as sourceMessageId,
-            c.createdAt as createdAt,
-            c.updatedAt as updatedAt
-        from Card c
-        join c.user u
-        where u.userId = :userId
-          and (:status is null or c.status = :status)
-          and (:cardType is null or c.cardType = :cardType)
-          and c.updatedAt >= coalesce(:updatedAfter, c.updatedAt)
-          and c.updatedAt <= coalesce(:updatedBefore, c.updatedAt)
-        order by c.updatedAt desc
-        """)
-    Slice<CardSummaryProjection> findSummariesByFiltersOrderByUpdatedAtDesc(
-            @Param("userId") String userId,
-            @Param("status") CardStatus status,
-            @Param("cardType") CardType cardType,
-            @Param("updatedAfter") Instant updatedAfter,
-            @Param("updatedBefore") Instant updatedBefore,
-            Pageable pageable
-    );
-
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepository.java
@@ -1,18 +1,12 @@
 package io.quintkard.quintkardapp.card;
 
-import java.time.Instant;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface CardSearchRepository {
 
-    Slice<CardSummaryProjection> searchHybridSummariesByUserId(
-            String userId,
-            CardStatus status,
-            CardType cardType,
-            Instant updatedAfter,
-            Instant updatedBefore,
-            String query,
+    Slice<CardSummaryProjection> searchHybridSummaries(
+            CardFilter filter,
             String embeddingModel,
             float[] queryEmbedding,
             Pageable pageable

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepository.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.card;
 
+import java.time.Instant;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -8,6 +9,9 @@ public interface CardSearchRepository {
     Slice<CardSummaryProjection> searchHybridSummariesByUserId(
             String userId,
             CardStatus status,
+            CardType cardType,
+            Instant updatedAfter,
+            Instant updatedBefore,
             String query,
             String embeddingModel,
             float[] queryEmbedding,

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java
@@ -54,6 +54,9 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
     public Slice<CardSummaryProjection> searchHybridSummariesByUserId(
             String userId,
             CardStatus status,
+            CardType cardType,
+            Instant updatedAfter,
+            Instant updatedBefore,
             String query,
             String embeddingModel,
             float[] queryEmbedding,
@@ -65,6 +68,9 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
         int semanticProbeLimit = Math.max((pageable.getPageNumber() + 1) * pageSize * 20, MIN_SEMANTIC_PROBE_LIMIT);
         String queryVector = toVectorLiteral(queryEmbedding);
         String statusClause = status == null ? "" : " and c.status = ?\n";
+        String cardTypeClause = cardType == null ? "" : " and c.card_type = ?\n";
+        String updatedAfterClause = updatedAfter == null ? "" : " and c.updated_at >= ?\n";
+        String updatedBeforeClause = updatedBefore == null ? "" : " and c.updated_at <= ?\n";
         String sql = """
                 with semantic_chunk_matches as (
                     select
@@ -75,7 +81,7 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
                     join users u on u.id = c.user_fk
                     where u.user_id = ?
                       and ce.embedding_model = ?
-                """ + statusClause + """
+                """ + statusClause + cardTypeClause + updatedAfterClause + updatedBeforeClause + """
                     order by ce.embedding_vector <=> cast(? as vector) asc
                     limit ?
                 ),
@@ -108,7 +114,7 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
                     from cards c
                     join users u on u.id = c.user_fk
                     where u.user_id = ?
-                """ + statusClause + """
+                """ + statusClause + cardTypeClause + updatedAfterClause + updatedBeforeClause + """
                       and to_tsvector(
                             'english',
                             coalesce(c.title, '') || ' ' ||
@@ -165,6 +171,15 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
         if (status != null) {
             parameters.add(status.name());
         }
+        if (cardType != null) {
+            parameters.add(cardType.name());
+        }
+        if (updatedAfter != null) {
+            parameters.add(Timestamp.from(updatedAfter));
+        }
+        if (updatedBefore != null) {
+            parameters.add(Timestamp.from(updatedBefore));
+        }
         parameters.add(queryVector);
         parameters.add(semanticProbeLimit);
         parameters.add(embeddingProperties.maxSemanticDistance());
@@ -172,6 +187,15 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
         parameters.add(userId);
         if (status != null) {
             parameters.add(status.name());
+        }
+        if (cardType != null) {
+            parameters.add(cardType.name());
+        }
+        if (updatedAfter != null) {
+            parameters.add(Timestamp.from(updatedAfter));
+        }
+        if (updatedBefore != null) {
+            parameters.add(Timestamp.from(updatedBefore));
         }
         parameters.add(query);
         parameters.add(textProbeLimit);

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java
@@ -51,17 +51,19 @@ public class CardSearchRepositoryImpl implements CardSearchRepository {
     }
 
     @Override
-    public Slice<CardSummaryProjection> searchHybridSummariesByUserId(
-            String userId,
-            CardStatus status,
-            CardType cardType,
-            Instant updatedAfter,
-            Instant updatedBefore,
-            String query,
+    public Slice<CardSummaryProjection> searchHybridSummaries(
+            CardFilter filter,
             String embeddingModel,
             float[] queryEmbedding,
             Pageable pageable
     ) {
+        String userId = filter.userId();
+        CardStatus status = filter.status();
+        CardType cardType = filter.cardType();
+        Instant updatedAfter = filter.updatedAfter();
+        Instant updatedBefore = filter.updatedBefore();
+        String query = filter.query();
+
         int pageSize = pageable.getPageSize();
         int offset = (int) pageable.getOffset();
         int textProbeLimit = Math.max((pageable.getPageNumber() + 1) * pageSize * 5, MIN_TEXT_PROBE_LIMIT);

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardService.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.card;
 
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
@@ -15,7 +16,16 @@ public interface CardService {
 
     Card changeCardStatus(String userId, UUID cardId, CardStatus status);
 
-    Slice<CardSummaryProjection> listCards(String userId, int page, int size, String query, CardStatus status);
+    Slice<CardSummaryProjection> listCards(
+            String userId,
+            int page,
+            int size,
+            String query,
+            CardStatus status,
+            CardType cardType,
+            Instant updatedAfter,
+            Instant updatedBefore
+    );
 
 //    List<Card> searchCards(String userId, String query, int limit);
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardService.java
@@ -1,6 +1,5 @@
 package io.quintkard.quintkardapp.card;
 
-import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
@@ -16,16 +15,7 @@ public interface CardService {
 
     Card changeCardStatus(String userId, UUID cardId, CardStatus status);
 
-    Slice<CardSummaryProjection> listCards(
-            String userId,
-            int page,
-            int size,
-            String query,
-            CardStatus status,
-            CardType cardType,
-            Instant updatedAfter,
-            Instant updatedBefore
-    );
+    Slice<CardSummaryProjection> listCards(CardFilter filter, int page, int size);
 
 //    List<Card> searchCards(String userId, String query, int limit);
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java
@@ -4,11 +4,11 @@ import io.quintkard.quintkardapp.embedding.EmbeddingProperties;
 import io.quintkard.quintkardapp.embedding.EmbeddingService;
 import io.quintkard.quintkardapp.user.User;
 import io.quintkard.quintkardapp.user.UserRepository;
-import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -109,38 +109,32 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional(readOnly = true)
-    public Slice<CardSummaryProjection> listCards(
-            String userId,
-            int page,
-            int size,
-            String query,
-            CardStatus status,
-            CardType cardType,
-            Instant updatedAfter,
-            Instant updatedBefore
-    ) {
-        Pageable pageable = PageRequest.of(Math.max(page, 0), normalizePageSize(size));
+    public Slice<CardSummaryProjection> listCards(CardFilter filter, int page, int size) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                normalizePageSize(size),
+                Sort.by(Sort.Direction.DESC, "updatedAt")
+        );
 
-        if (query == null || query.isBlank()) {
-            return cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
-                    userId,
-                    status,
-                    cardType,
-                    updatedAfter,
-                    updatedBefore,
-                    pageable
-            );
+        if (filter.query() == null || filter.query().isBlank()) {
+            return cardRepository.findAll(CardSpecifications.fromFilter(filter), pageable)
+                    .map(CardSummaryItem::from);
         }
 
-        return cardRepository.searchHybridSummariesByUserId(
-                userId,
-                status,
-                cardType,
-                updatedAfter,
-                updatedBefore,
-                query.trim(),
+        String normalizedQuery = filter.query().trim();
+        CardFilter normalizedFilter = new CardFilter(
+                filter.userId(),
+                normalizedQuery,
+                filter.status(),
+                filter.cardType(),
+                filter.updatedAfter(),
+                filter.updatedBefore()
+        );
+
+        return cardRepository.searchHybridSummaries(
+                normalizedFilter,
                 embeddingProperties.model(),
-                embeddingService.embed(query.trim()),
+                embeddingService.embed(normalizedQuery),
                 pageable
         );
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java
@@ -4,6 +4,7 @@ import io.quintkard.quintkardapp.embedding.EmbeddingProperties;
 import io.quintkard.quintkardapp.embedding.EmbeddingService;
 import io.quintkard.quintkardapp.user.User;
 import io.quintkard.quintkardapp.user.UserRepository;
+import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
@@ -108,19 +109,35 @@ public class CardServiceImpl implements CardService {
 
     @Override
     @Transactional(readOnly = true)
-    public Slice<CardSummaryProjection> listCards(String userId, int page, int size, String query, CardStatus status) {
+    public Slice<CardSummaryProjection> listCards(
+            String userId,
+            int page,
+            int size,
+            String query,
+            CardStatus status,
+            CardType cardType,
+            Instant updatedAfter,
+            Instant updatedBefore
+    ) {
         Pageable pageable = PageRequest.of(Math.max(page, 0), normalizePageSize(size));
 
         if (query == null || query.isBlank()) {
-            if (status == null) {
-                return cardRepository.findSummariesByUserUserIdOrderByUpdatedAtDesc(userId, pageable);
-            }
-            return cardRepository.findSummariesByUserUserIdAndStatusOrderByUpdatedAtDesc(userId, status, pageable);
+            return cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
+                    userId,
+                    status,
+                    cardType,
+                    updatedAfter,
+                    updatedBefore,
+                    pageable
+            );
         }
 
         return cardRepository.searchHybridSummariesByUserId(
                 userId,
                 status,
+                cardType,
+                updatedAfter,
+                updatedBefore,
                 query.trim(),
                 embeddingProperties.model(),
                 embeddingService.embed(query.trim()),

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSpecifications.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSpecifications.java
@@ -1,0 +1,59 @@
+package io.quintkard.quintkardapp.card;
+
+import org.springframework.data.jpa.domain.Specification;
+
+public final class CardSpecifications {
+
+    private CardSpecifications() {
+    }
+
+    public static Specification<Card> fromFilter(CardFilter filter) {
+        Specification<Card> specification = Specification.where(hasUserId(filter.userId()));
+        specification = and(specification, hasStatus(filter.status()));
+        specification = and(specification, hasCardType(filter.cardType()));
+        specification = and(specification, updatedAfter(filter.updatedAfter()));
+        specification = and(specification, updatedBefore(filter.updatedBefore()));
+        return specification;
+    }
+
+    private static Specification<Card> and(Specification<Card> left, Specification<Card> right) {
+        return right == null ? left : left.and(right);
+    }
+
+    private static Specification<Card> hasUserId(String userId) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.join("user").get("userId"), userId);
+    }
+
+    private static Specification<Card> hasStatus(CardStatus status) {
+        if (status == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("status"), status);
+    }
+
+    private static Specification<Card> hasCardType(CardType cardType) {
+        if (cardType == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("cardType"), cardType);
+    }
+
+    private static Specification<Card> updatedAfter(java.time.Instant updatedAfter) {
+        if (updatedAfter == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("updatedAt"), updatedAfter);
+    }
+
+    private static Specification<Card> updatedBefore(java.time.Instant updatedBefore) {
+        if (updatedBefore == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("updatedAt"), updatedBefore);
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSummaryItem.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSummaryItem.java
@@ -18,6 +18,22 @@ public record CardSummaryItem(
         Instant updatedAt
 ) implements CardSummaryProjection {
 
+    public static CardSummaryItem from(Card card) {
+        return new CardSummaryItem(
+                card.getId(),
+                card.getUser().getUserId(),
+                card.getTitle(),
+                card.getSummary(),
+                card.getCardType(),
+                card.getStatus(),
+                card.getPriority(),
+                card.getDueDate(),
+                card.getSourceMessageId(),
+                card.getCreatedAt(),
+                card.getUpdatedAt()
+        );
+    }
+
     @Override
     public UUID getId() {
         return id;

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageController.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageController.java
@@ -39,10 +39,8 @@ public class MessageController {
             @RequestParam(required = false) Instant ingestedAfter,
             @RequestParam(required = false) Instant ingestedBefore
     ) {
-        Slice<MessageSummaryProjection> messages = messageService.listMessages(
+        MessageFilter filter = new MessageFilter(
                 authentication.getName(),
-                page,
-                size,
                 query,
                 status,
                 sourceService,
@@ -50,6 +48,7 @@ public class MessageController {
                 ingestedAfter,
                 ingestedBefore
         );
+        Slice<MessageSummaryProjection> messages = messageService.listMessages(filter, page, size);
 
         return MessageSliceResponse.from(messages);
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageController.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageController.java
@@ -1,6 +1,7 @@
 package io.quintkard.quintkardapp.message;
 
 import jakarta.validation.Valid;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
@@ -32,14 +33,22 @@ public class MessageController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String query,
-            @RequestParam(required = false) MessageStatus status
+            @RequestParam(required = false) MessageStatus status,
+            @RequestParam(required = false) String sourceService,
+            @RequestParam(required = false) String messageType,
+            @RequestParam(required = false) Instant ingestedAfter,
+            @RequestParam(required = false) Instant ingestedBefore
     ) {
         Slice<MessageSummaryProjection> messages = messageService.listMessages(
                 authentication.getName(),
                 page,
                 size,
                 query,
-                status
+                status,
+                sourceService,
+                messageType,
+                ingestedAfter,
+                ingestedBefore
         );
 
         return MessageSliceResponse.from(messages);

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageFilter.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageFilter.java
@@ -1,0 +1,14 @@
+package io.quintkard.quintkardapp.message;
+
+import java.time.Instant;
+
+public record MessageFilter(
+        String userId,
+        String query,
+        MessageStatus status,
+        String sourceService,
+        String messageType,
+        Instant ingestedAfter,
+        Instant ingestedBefore
+) {
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
@@ -1,16 +1,14 @@
 package io.quintkard.quintkardapp.message;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MessageRepository extends JpaRepository<Message, UUID> {
+public interface MessageRepository extends JpaRepository<Message, UUID>, JpaSpecificationExecutor<Message>, MessageSearchRepository {
 
     @Query(
         value = """
@@ -30,94 +28,4 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
     List<Message> findAllByIdIn(List<UUID> ids);
 
     Optional<Message> findByIdAndUserUserId(UUID id, String userId);
-
-    @Query("""
-        select
-            m.id as id,
-            u.userId as userId,
-            m.sourceService as sourceService,
-            m.externalMessageId as externalMessageId,
-            m.messageType as messageType,
-            m.status as status,
-            m.summary as summary,
-            m.ingestedAt as ingestedAt,
-            m.sourceCreatedAt as sourceCreatedAt
-        from Message m
-        join m.user u
-        where u.userId = :userId
-          and (:status is null or m.status = :status)
-          and (:sourceService is null or m.sourceService = :sourceService)
-          and (:messageType is null or m.messageType = :messageType)
-          and m.ingestedAt >= coalesce(:ingestedAfter, m.ingestedAt)
-          and m.ingestedAt <= coalesce(:ingestedBefore, m.ingestedAt)
-        order by m.ingestedAt desc
-        """)
-    Slice<MessageSummaryProjection> findSummariesByFiltersOrderByIngestedAtDesc(
-            @Param("userId") String userId,
-            @Param("status") MessageStatus status,
-            @Param("sourceService") String sourceService,
-            @Param("messageType") String messageType,
-            @Param("ingestedAfter") Instant ingestedAfter,
-            @Param("ingestedBefore") Instant ingestedBefore,
-            Pageable pageable
-    );
-
-    @Query(
-        value = """
-            select
-                m.id as id,
-                u.user_id as userId,
-                m.source_service as sourceService,
-                m.external_message_id as externalMessageId,
-                m.message_type as messageType,
-                m.status as status,
-                m.summary as summary,
-                m.ingested_at as ingestedAt,
-                m.source_created_at as sourceCreatedAt
-            from messages m
-            join users u on u.id = m.user_fk
-            where u.user_id = :userId
-              and (:status is null or m.status = :status)
-              and (:sourceService is null or m.source_service = :sourceService)
-              and (:messageType is null or m.message_type = :messageType)
-              and m.ingested_at >= coalesce(:ingestedAfter, m.ingested_at)
-              and m.ingested_at <= coalesce(:ingestedBefore, m.ingested_at)
-              and to_tsvector(
-                    'english',
-                    concat_ws(
-                        ' ',
-                        coalesce(m.payload, ''),
-                        coalesce(m.source_service, ''),
-                        coalesce(m.external_message_id, ''),
-                        coalesce(m.message_type, '')
-                    )
-                  ) @@ websearch_to_tsquery('english', :query)
-            order by
-                ts_rank(
-                    to_tsvector(
-                        'english',
-                        concat_ws(
-                            ' ',
-                            coalesce(m.payload, ''),
-                            coalesce(m.source_service, ''),
-                            coalesce(m.external_message_id, ''),
-                            coalesce(m.message_type, '')
-                        )
-                    ),
-                    websearch_to_tsquery('english', :query)
-                ) desc,
-                m.ingested_at desc
-            """,
-        nativeQuery = true
-    )
-    Slice<MessageSummaryProjection> searchSummariesByUserId(
-            @Param("userId") String userId,
-            @Param("status") String status,
-            @Param("sourceService") String sourceService,
-            @Param("messageType") String messageType,
-            @Param("ingestedAfter") Instant ingestedAfter,
-            @Param("ingestedBefore") Instant ingestedBefore,
-            @Param("query") String query,
-            Pageable pageable
-    );
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.message;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,33 +45,20 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
         from Message m
         join m.user u
         where u.userId = :userId
+          and (:status is null or m.status = :status)
+          and (:sourceService is null or m.sourceService = :sourceService)
+          and (:messageType is null or m.messageType = :messageType)
+          and m.ingestedAt >= coalesce(:ingestedAfter, m.ingestedAt)
+          and m.ingestedAt <= coalesce(:ingestedBefore, m.ingestedAt)
         order by m.ingestedAt desc
         """)
-    Slice<MessageSummaryProjection> findSummariesByUserUserIdOrderByIngestedAtDesc(
-            @Param("userId") String userId,
-            Pageable pageable
-    );
-
-    @Query("""
-        select
-            m.id as id,
-            u.userId as userId,
-            m.sourceService as sourceService,
-            m.externalMessageId as externalMessageId,
-            m.messageType as messageType,
-            m.status as status,
-            m.summary as summary,
-            m.ingestedAt as ingestedAt,
-            m.sourceCreatedAt as sourceCreatedAt
-        from Message m
-        join m.user u
-        where u.userId = :userId
-          and m.status = :status
-        order by m.ingestedAt desc
-        """)
-    Slice<MessageSummaryProjection> findSummariesByUserUserIdAndStatusOrderByIngestedAtDesc(
+    Slice<MessageSummaryProjection> findSummariesByFiltersOrderByIngestedAtDesc(
             @Param("userId") String userId,
             @Param("status") MessageStatus status,
+            @Param("sourceService") String sourceService,
+            @Param("messageType") String messageType,
+            @Param("ingestedAfter") Instant ingestedAfter,
+            @Param("ingestedBefore") Instant ingestedBefore,
             Pageable pageable
     );
 
@@ -90,6 +78,10 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
             join users u on u.id = m.user_fk
             where u.user_id = :userId
               and (:status is null or m.status = :status)
+              and (:sourceService is null or m.source_service = :sourceService)
+              and (:messageType is null or m.message_type = :messageType)
+              and m.ingested_at >= coalesce(:ingestedAfter, m.ingested_at)
+              and m.ingested_at <= coalesce(:ingestedBefore, m.ingested_at)
               and to_tsvector(
                     'english',
                     concat_ws(
@@ -121,6 +113,10 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
     Slice<MessageSummaryProjection> searchSummariesByUserId(
             @Param("userId") String userId,
             @Param("status") String status,
+            @Param("sourceService") String sourceService,
+            @Param("messageType") String messageType,
+            @Param("ingestedAfter") Instant ingestedAfter,
+            @Param("ingestedBefore") Instant ingestedBefore,
             @Param("query") String query,
             Pageable pageable
     );

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepository.java
@@ -1,0 +1,9 @@
+package io.quintkard.quintkardapp.message;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface MessageSearchRepository {
+
+    Slice<MessageSummaryProjection> searchSummaries(MessageFilter filter, Pageable pageable);
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImpl.java
@@ -1,0 +1,125 @@
+package io.quintkard.quintkardapp.message;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MessageSearchRepositoryImpl implements MessageSearchRepository {
+
+    private static final RowMapper<MessageSummaryProjection> MESSAGE_SUMMARY_ROW_MAPPER = new RowMapper<>() {
+        @Override
+        public MessageSummaryProjection mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new MessageSummaryItem(
+                    rs.getObject("id", UUID.class),
+                    rs.getString("user_id"),
+                    rs.getString("source_service"),
+                    rs.getString("external_message_id"),
+                    rs.getString("message_type"),
+                    MessageStatus.valueOf(rs.getString("status")),
+                    rs.getString("summary"),
+                    toInstant(rs, "ingested_at"),
+                    toInstant(rs, "source_created_at")
+            );
+        }
+    };
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public MessageSearchRepositoryImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Slice<MessageSummaryProjection> searchSummaries(MessageFilter filter, Pageable pageable) {
+        String sourceServiceClause = filter.sourceService() == null ? "" : " and m.source_service = ?\n";
+        String messageTypeClause = filter.messageType() == null ? "" : " and m.message_type = ?\n";
+        String ingestedAfterClause = filter.ingestedAfter() == null ? "" : " and m.ingested_at >= ?\n";
+        String ingestedBeforeClause = filter.ingestedBefore() == null ? "" : " and m.ingested_at <= ?\n";
+
+        String sql = """
+                select
+                    m.id,
+                    u.user_id,
+                    m.source_service,
+                    m.external_message_id,
+                    m.message_type,
+                    m.status,
+                    m.summary,
+                    m.ingested_at,
+                    m.source_created_at
+                from messages m
+                join users u on u.id = m.user_fk
+                where u.user_id = ?
+                  and (? is null or m.status = ?)
+                """ + sourceServiceClause + messageTypeClause + ingestedAfterClause + ingestedBeforeClause + """
+                  and to_tsvector(
+                        'english',
+                        concat_ws(
+                            ' ',
+                            coalesce(m.payload, ''),
+                            coalesce(m.source_service, ''),
+                            coalesce(m.external_message_id, ''),
+                            coalesce(m.message_type, '')
+                        )
+                    ) @@ websearch_to_tsquery('english', ?)
+                order by
+                    ts_rank(
+                        to_tsvector(
+                            'english',
+                            concat_ws(
+                                ' ',
+                                coalesce(m.payload, ''),
+                                coalesce(m.source_service, ''),
+                                coalesce(m.external_message_id, ''),
+                                coalesce(m.message_type, '')
+                            )
+                        ),
+                        websearch_to_tsquery('english', ?)
+                    ) desc,
+                    m.ingested_at desc
+                limit ?
+                offset ?
+                """;
+
+        List<Object> parameters = new ArrayList<>();
+        parameters.add(filter.userId());
+        parameters.add(filter.status() == null ? null : filter.status().name());
+        parameters.add(filter.status() == null ? null : filter.status().name());
+        if (filter.sourceService() != null) {
+            parameters.add(filter.sourceService());
+        }
+        if (filter.messageType() != null) {
+            parameters.add(filter.messageType());
+        }
+        if (filter.ingestedAfter() != null) {
+            parameters.add(java.sql.Timestamp.from(filter.ingestedAfter()));
+        }
+        if (filter.ingestedBefore() != null) {
+            parameters.add(java.sql.Timestamp.from(filter.ingestedBefore()));
+        }
+        parameters.add(filter.query());
+        parameters.add(filter.query());
+        parameters.add(pageable.getPageSize() + 1);
+        parameters.add(pageable.getOffset());
+
+        List<MessageSummaryProjection> rows = jdbcTemplate.query(sql, MESSAGE_SUMMARY_ROW_MAPPER, parameters.toArray());
+        boolean hasNext = rows.size() > pageable.getPageSize();
+        List<MessageSummaryProjection> items = hasNext ? rows.subList(0, pageable.getPageSize()) : rows;
+        return new SliceImpl<>(items, pageable, hasNext);
+    }
+
+    private static Instant toInstant(ResultSet rs, String column) throws SQLException {
+        java.sql.Timestamp timestamp = rs.getTimestamp(column);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageService.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.message;
 
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
@@ -7,7 +8,17 @@ public interface MessageService {
 
     Message getMessage(String userId, UUID messageId);
 
-    Slice<MessageSummaryProjection> listMessages(String userId, int page, int size, String query, MessageStatus status);
+    Slice<MessageSummaryProjection> listMessages(
+            String userId,
+            int page,
+            int size,
+            String query,
+            MessageStatus status,
+            String sourceService,
+            String messageType,
+            Instant ingestedAfter,
+            Instant ingestedBefore
+    );
 
     Message updateMessageStatus(String userId, UUID messageId, MessageStatus status);
 

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageService.java
@@ -1,6 +1,5 @@
 package io.quintkard.quintkardapp.message;
 
-import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
@@ -8,17 +7,7 @@ public interface MessageService {
 
     Message getMessage(String userId, UUID messageId);
 
-    Slice<MessageSummaryProjection> listMessages(
-            String userId,
-            int page,
-            int size,
-            String query,
-            MessageStatus status,
-            String sourceService,
-            String messageType,
-            Instant ingestedAfter,
-            Instant ingestedBefore
-    );
+    Slice<MessageSummaryProjection> listMessages(MessageFilter filter, int page, int size);
 
     Message updateMessageStatus(String userId, UUID messageId, MessageStatus status);
 

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageServiceImpl.java
@@ -1,5 +1,6 @@
 package io.quintkard.quintkardapp.message;
 
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -33,20 +34,35 @@ public class MessageServiceImpl implements MessageService {
             int page,
             int size,
             String query,
-            MessageStatus status
+            MessageStatus status,
+            String sourceService,
+            String messageType,
+            Instant ingestedAfter,
+            Instant ingestedBefore
     ) {
         Pageable pageable = PageRequest.of(Math.max(page, 0), normalizePageSize(size));
+        String normalizedSourceService = trimToNull(sourceService);
+        String normalizedMessageType = trimToNull(messageType);
 
         if (query == null || query.isBlank()) {
-            if (status == null) {
-                return messageRepository.findSummariesByUserUserIdOrderByIngestedAtDesc(userId, pageable);
-            }
-            return messageRepository.findSummariesByUserUserIdAndStatusOrderByIngestedAtDesc(userId, status, pageable);
+            return messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
+                    userId,
+                    status,
+                    normalizedSourceService,
+                    normalizedMessageType,
+                    ingestedAfter,
+                    ingestedBefore,
+                    pageable
+            );
         }
 
         return messageRepository.searchSummariesByUserId(
                 userId,
                 status == null ? null : status.name(),
+                normalizedSourceService,
+                normalizedMessageType,
+                ingestedAfter,
+                ingestedBefore,
                 query.trim(),
                 pageable
         );
@@ -81,5 +97,13 @@ public class MessageServiceImpl implements MessageService {
             case FAILED -> message.markFailed();
             case SUCCESS -> message.markSuccess();
         }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageServiceImpl.java
@@ -1,9 +1,9 @@
 package io.quintkard.quintkardapp.message;
 
-import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,41 +29,29 @@ public class MessageServiceImpl implements MessageService {
 
     @Override
     @Transactional(readOnly = true)
-    public Slice<MessageSummaryProjection> listMessages(
-            String userId,
-            int page,
-            int size,
-            String query,
-            MessageStatus status,
-            String sourceService,
-            String messageType,
-            Instant ingestedAfter,
-            Instant ingestedBefore
-    ) {
-        Pageable pageable = PageRequest.of(Math.max(page, 0), normalizePageSize(size));
-        String normalizedSourceService = trimToNull(sourceService);
-        String normalizedMessageType = trimToNull(messageType);
+    public Slice<MessageSummaryProjection> listMessages(MessageFilter filter, int page, int size) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                normalizePageSize(size),
+                Sort.by(Sort.Direction.DESC, "ingestedAt")
+        );
+        MessageFilter normalizedFilter = new MessageFilter(
+                filter.userId(),
+                trimToNull(filter.query()),
+                filter.status(),
+                trimToNull(filter.sourceService()),
+                trimToNull(filter.messageType()),
+                filter.ingestedAfter(),
+                filter.ingestedBefore()
+        );
 
-        if (query == null || query.isBlank()) {
-            return messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
-                    userId,
-                    status,
-                    normalizedSourceService,
-                    normalizedMessageType,
-                    ingestedAfter,
-                    ingestedBefore,
-                    pageable
-            );
+        if (normalizedFilter.query() == null) {
+            return messageRepository.findAll(MessageSpecifications.fromFilter(normalizedFilter), pageable)
+                    .map(MessageSummaryItem::from);
         }
 
-        return messageRepository.searchSummariesByUserId(
-                userId,
-                status == null ? null : status.name(),
-                normalizedSourceService,
-                normalizedMessageType,
-                ingestedAfter,
-                ingestedBefore,
-                query.trim(),
+        return messageRepository.searchSummaries(
+                normalizedFilter,
                 pageable
         );
     }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSpecifications.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSpecifications.java
@@ -1,0 +1,68 @@
+package io.quintkard.quintkardapp.message;
+
+import org.springframework.data.jpa.domain.Specification;
+
+public final class MessageSpecifications {
+
+    private MessageSpecifications() {
+    }
+
+    public static Specification<Message> fromFilter(MessageFilter filter) {
+        Specification<Message> specification = Specification.where(hasUserId(filter.userId()));
+        specification = and(specification, hasStatus(filter.status()));
+        specification = and(specification, hasSourceService(filter.sourceService()));
+        specification = and(specification, hasMessageType(filter.messageType()));
+        specification = and(specification, ingestedAfter(filter.ingestedAfter()));
+        specification = and(specification, ingestedBefore(filter.ingestedBefore()));
+        return specification;
+    }
+
+    private static Specification<Message> and(Specification<Message> left, Specification<Message> right) {
+        return right == null ? left : left.and(right);
+    }
+
+    private static Specification<Message> hasUserId(String userId) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.join("user").get("userId"), userId);
+    }
+
+    private static Specification<Message> hasStatus(MessageStatus status) {
+        if (status == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("status"), status);
+    }
+
+    private static Specification<Message> hasSourceService(String sourceService) {
+        if (sourceService == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("sourceService"), sourceService);
+    }
+
+    private static Specification<Message> hasMessageType(String messageType) {
+        if (messageType == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("messageType"), messageType);
+    }
+
+    private static Specification<Message> ingestedAfter(java.time.Instant ingestedAfter) {
+        if (ingestedAfter == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("ingestedAt"), ingestedAfter);
+    }
+
+    private static Specification<Message> ingestedBefore(java.time.Instant ingestedBefore) {
+        if (ingestedBefore == null) {
+            return null;
+        }
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("ingestedAt"), ingestedBefore);
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSummaryItem.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSummaryItem.java
@@ -1,0 +1,76 @@
+package io.quintkard.quintkardapp.message;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record MessageSummaryItem(
+        UUID id,
+        String userId,
+        String sourceService,
+        String externalMessageId,
+        String messageType,
+        MessageStatus status,
+        String summary,
+        Instant ingestedAt,
+        Instant sourceCreatedAt
+) implements MessageSummaryProjection {
+
+    public static MessageSummaryItem from(Message message) {
+        return new MessageSummaryItem(
+                message.getId(),
+                message.getUser().getUserId(),
+                message.getSourceService(),
+                message.getExternalMessageId(),
+                message.getMessageType(),
+                message.getStatus(),
+                message.getSummary(),
+                message.getIngestedAt(),
+                message.getSourceCreatedAt()
+        );
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public String getSourceService() {
+        return sourceService;
+    }
+
+    @Override
+    public String getExternalMessageId() {
+        return externalMessageId;
+    }
+
+    @Override
+    public String getMessageType() {
+        return messageType;
+    }
+
+    @Override
+    public MessageStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getSummary() {
+        return summary;
+    }
+
+    @Override
+    public Instant getIngestedAt() {
+        return ingestedAt;
+    }
+
+    @Override
+    public Instant getSourceCreatedAt() {
+        return sourceCreatedAt;
+    }
+}

--- a/quintkard-app/src/main/resources/db/migration/V2__add_filtering_indexes.sql
+++ b/quintkard-app/src/main/resources/db/migration/V2__add_filtering_indexes.sql
@@ -1,0 +1,8 @@
+create index idx_cards_user_card_type_updated_at
+    on cards (user_fk, card_type, updated_at desc);
+
+create index idx_messages_user_source_service_ingested_at
+    on messages (user_fk, source_service, ingested_at desc);
+
+create index idx_messages_user_message_type_ingested_at
+    on messages (user_fk, message_type, ingested_at desc);

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/FlywaySchemaMigrationIntegrationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/FlywaySchemaMigrationIntegrationTest.java
@@ -43,6 +43,7 @@ class FlywaySchemaMigrationIntegrationTest {
     @Test
     void migrateCreatesSchemaAndIndexes() {
         assertEquals(1, count("select count(*) from flyway_schema_history where version = '1' and success = true"));
+        assertEquals(1, count("select count(*) from flyway_schema_history where version = '2' and success = true"));
         assertEquals(1, count("select count(*) from information_schema.tables where table_name = 'users'"));
         assertEquals(1, count("select count(*) from information_schema.tables where table_name = 'cards'"));
         assertEquals(1, count("select count(*) from information_schema.tables where table_name = 'card_embeddings'"));
@@ -51,8 +52,11 @@ class FlywaySchemaMigrationIntegrationTest {
         assertEquals(1, count("select count(*) from information_schema.tables where table_name = 'orchestrator_configs'"));
         assertEquals(1, count("select count(*) from information_schema.tables where table_name = 'orchestration_active_agents'"));
         assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_cards_search'"));
+        assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_cards_user_card_type_updated_at'"));
         assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_messages_search'"));
         assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_messages_status_ingested_at'"));
+        assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_messages_user_source_service_ingested_at'"));
+        assertEquals(1, count("select count(*) from pg_indexes where indexname = 'idx_messages_user_message_type_ingested_at'"));
 
         String dataType = jdbcTemplate.queryForObject(
                 """

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/agenttool/CardToolsTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/agenttool/CardToolsTest.java
@@ -205,7 +205,7 @@ class CardToolsTest {
         when(summary.getCardType()).thenReturn(CardType.FOLLOW_UP);
         when(summary.getStatus()).thenReturn(CardStatus.OPEN);
         when(summary.getPriority()).thenReturn(CardPriority.MEDIUM);
-        when(cardService.listCards("admin", 0, 10, "invoice", CardStatus.OPEN))
+        when(cardService.listCards("admin", 0, 10, "invoice", CardStatus.OPEN, null, null, null))
                 .thenReturn(new SliceImpl<>(List.of(summary)));
 
         CardSliceResponse response = (CardSliceResponse) tool.execute(new AiToolExecutionRequest(
@@ -220,7 +220,7 @@ class CardToolsTest {
 
         assertEquals(1, response.items().size());
         assertEquals("Follow up", response.items().getFirst().title());
-        verify(cardService).listCards("admin", 0, 10, "invoice", CardStatus.OPEN);
+        verify(cardService).listCards("admin", 0, 10, "invoice", CardStatus.OPEN, null, null, null);
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/agenttool/CardToolsTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/agenttool/CardToolsTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import io.quintkard.quintkardapp.card.Card;
 import io.quintkard.quintkardapp.card.CardPriority;
+import io.quintkard.quintkardapp.card.CardFilter;
 import io.quintkard.quintkardapp.card.CardRequest;
 import io.quintkard.quintkardapp.card.CardResponse;
 import io.quintkard.quintkardapp.card.CardService;
@@ -205,7 +206,11 @@ class CardToolsTest {
         when(summary.getCardType()).thenReturn(CardType.FOLLOW_UP);
         when(summary.getStatus()).thenReturn(CardStatus.OPEN);
         when(summary.getPriority()).thenReturn(CardPriority.MEDIUM);
-        when(cardService.listCards("admin", 0, 10, "invoice", CardStatus.OPEN, null, null, null))
+        when(cardService.listCards(
+                new CardFilter("admin", "invoice", CardStatus.OPEN, null, null, null),
+                0,
+                10
+        ))
                 .thenReturn(new SliceImpl<>(List.of(summary)));
 
         CardSliceResponse response = (CardSliceResponse) tool.execute(new AiToolExecutionRequest(
@@ -220,7 +225,11 @@ class CardToolsTest {
 
         assertEquals(1, response.items().size());
         assertEquals("Follow up", response.items().getFirst().title());
-        verify(cardService).listCards("admin", 0, 10, "invoice", CardStatus.OPEN, null, null, null);
+        verify(cardService).listCards(
+                new CardFilter("admin", "invoice", CardStatus.OPEN, null, null, null),
+                0,
+                10
+        );
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardControllerTest.java
@@ -49,21 +49,42 @@ class CardControllerTest {
         when(summary.getDueDate()).thenReturn(LocalDate.of(2026, 5, 29));
         when(summary.getCreatedAt()).thenReturn(Instant.parse("2026-04-05T00:00:00Z"));
         when(summary.getUpdatedAt()).thenReturn(Instant.parse("2026-04-05T01:00:00Z"));
-        when(cardService.listCards("admin", 1, 10, "invoice", CardStatus.OPEN))
+        when(cardService.listCards(
+                "admin",
+                1,
+                10,
+                "invoice",
+                CardStatus.OPEN,
+                CardType.FOLLOW_UP,
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        ))
                 .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(1, 10), false));
 
         mockMvc.perform(authorized(get("/api/cards"))
                         .param("page", "1")
                         .param("size", "10")
                         .param("query", "invoice")
-                        .param("status", "OPEN"))
+                        .param("status", "OPEN")
+                        .param("cardType", "FOLLOW_UP")
+                        .param("updatedAfter", "2026-04-05T00:00:00Z")
+                        .param("updatedBefore", "2026-04-06T00:00:00Z"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items[0].id").value(cardId.toString()))
                 .andExpect(jsonPath("$.items[0].title").value("Follow up"))
                 .andExpect(jsonPath("$.page").value(1))
                 .andExpect(jsonPath("$.size").value(10));
 
-        verify(cardService).listCards("admin", 1, 10, "invoice", CardStatus.OPEN);
+        verify(cardService).listCards(
+                "admin",
+                1,
+                10,
+                "invoice",
+                CardStatus.OPEN,
+                CardType.FOLLOW_UP,
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardControllerTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -50,16 +51,18 @@ class CardControllerTest {
         when(summary.getCreatedAt()).thenReturn(Instant.parse("2026-04-05T00:00:00Z"));
         when(summary.getUpdatedAt()).thenReturn(Instant.parse("2026-04-05T01:00:00Z"));
         when(cardService.listCards(
-                "admin",
+                new CardFilter(
+                        "admin",
+                        "invoice",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 1,
-                10,
-                "invoice",
-                CardStatus.OPEN,
-                CardType.FOLLOW_UP,
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                10
         ))
-                .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(1, 10), false));
+                .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(1, 10, Sort.by("updatedAt").descending()), false));
 
         mockMvc.perform(authorized(get("/api/cards"))
                         .param("page", "1")
@@ -76,14 +79,16 @@ class CardControllerTest {
                 .andExpect(jsonPath("$.size").value(10));
 
         verify(cardService).listCards(
-                "admin",
+                new CardFilter(
+                        "admin",
+                        "invoice",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 1,
-                10,
-                "invoice",
-                CardStatus.OPEN,
-                CardType.FOLLOW_UP,
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                10
         );
     }
 

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImplIntegrationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImplIntegrationTest.java
@@ -92,7 +92,7 @@ class CardSearchRepositoryImplIntegrationTest {
     }
 
     @Test
-    void searchHybridSummariesByUserIdFiltersByUserAndStatus() {
+    void searchHybridSummariesFiltersByUserAndStatus() {
         insertUser(1L, "admin");
         insertUser(2L, "other");
         UUID adminOpen = insertCard(1L, "Invoice follow up", "August invoice", "Need vendor response", CardStatus.OPEN, Instant.parse("2026-04-05T00:00:00Z"));
@@ -102,13 +102,8 @@ class CardSearchRepositoryImplIntegrationTest {
         UUID otherOpen = insertCard(2L, "Invoice for other user", "Other invoice", "Other user content", CardStatus.OPEN, Instant.parse("2026-04-05T00:10:00Z"));
         insertEmbedding(otherOpen, "[1,0,0]");
 
-        Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
-                "admin",
-                CardStatus.OPEN,
-                null,
-                null,
-                null,
-                "invoice",
+        Slice<CardSummaryProjection> result = repository.searchHybridSummaries(
+                new CardFilter("admin", "invoice", CardStatus.OPEN, null, null, null),
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
                 PageRequest.of(0, 10)
@@ -119,20 +114,15 @@ class CardSearchRepositoryImplIntegrationTest {
     }
 
     @Test
-    void searchHybridSummariesByUserIdIncludesSemanticOnlyMatchesWithinThreshold() {
+    void searchHybridSummariesIncludesSemanticOnlyMatchesWithinThreshold() {
         insertUser(1L, "admin");
         UUID textCard = insertCard(1L, "Invoice follow up", "Need action", "Vendor correction pending", CardStatus.OPEN, Instant.parse("2026-04-05T00:00:00Z"));
         insertEmbedding(textCard, "[0,1,0]");
         UUID semanticCard = insertCard(1L, "Account update", "Billing review", "Review customer account changes", CardStatus.OPEN, Instant.parse("2026-04-05T01:00:00Z"));
         insertEmbedding(semanticCard, "[1,0,0]");
 
-        Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
-                "admin",
-                null,
-                null,
-                null,
-                null,
-                "invoice",
+        Slice<CardSummaryProjection> result = repository.searchHybridSummaries(
+                new CardFilter("admin", "invoice", null, null, null, null),
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
                 PageRequest.of(0, 10)
@@ -145,20 +135,15 @@ class CardSearchRepositoryImplIntegrationTest {
     }
 
     @Test
-    void searchHybridSummariesByUserIdExcludesWeakSemanticMatchesOutsideThreshold() {
+    void searchHybridSummariesExcludesWeakSemanticMatchesOutsideThreshold() {
         insertUser(1L, "admin");
         UUID textCard = insertCard(1L, "Invoice follow up", "Need action", "Vendor correction pending", CardStatus.OPEN, Instant.parse("2026-04-05T00:00:00Z"));
         insertEmbedding(textCard, "[0,1,0]");
         UUID weakSemanticCard = insertCard(1L, "Account update", "Billing review", "Review customer account changes", CardStatus.OPEN, Instant.parse("2026-04-05T01:00:00Z"));
         insertEmbedding(weakSemanticCard, "[0,1,0]");
 
-        Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
-                "admin",
-                null,
-                null,
-                null,
-                null,
-                "invoice",
+        Slice<CardSummaryProjection> result = repository.searchHybridSummaries(
+                new CardFilter("admin", "invoice", null, null, null, null),
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
                 PageRequest.of(0, 10)
@@ -169,7 +154,7 @@ class CardSearchRepositoryImplIntegrationTest {
     }
 
     @Test
-    void searchHybridSummariesByUserIdAppliesCardTypeAndUpdatedAfterFilters() {
+    void searchHybridSummariesAppliesCardTypeAndUpdatedAfterFilters() {
         insertUser(1L, "admin");
         UUID matchingCard = insertCard(
                 1L,
@@ -202,13 +187,15 @@ class CardSearchRepositoryImplIntegrationTest {
         );
         insertEmbedding(tooOldCard, "[1,0,0]");
 
-        Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
-                "admin",
-                CardStatus.OPEN,
-                CardType.FOLLOW_UP,
-                Instant.parse("2026-04-05T01:00:00Z"),
-                Instant.parse("2026-04-05T03:00:00Z"),
-                "invoice",
+        Slice<CardSummaryProjection> result = repository.searchHybridSummaries(
+                new CardFilter(
+                        "admin",
+                        "invoice",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T01:00:00Z"),
+                        Instant.parse("2026-04-05T03:00:00Z")
+                ),
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
                 PageRequest.of(0, 10)

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImplIntegrationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImplIntegrationTest.java
@@ -105,6 +105,9 @@ class CardSearchRepositoryImplIntegrationTest {
         Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
                 "admin",
                 CardStatus.OPEN,
+                null,
+                null,
+                null,
                 "invoice",
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
@@ -125,6 +128,9 @@ class CardSearchRepositoryImplIntegrationTest {
 
         Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
                 "admin",
+                null,
+                null,
+                null,
                 null,
                 "invoice",
                 "gemini-embedding-001",
@@ -149,6 +155,9 @@ class CardSearchRepositoryImplIntegrationTest {
         Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
                 "admin",
                 null,
+                null,
+                null,
+                null,
                 "invoice",
                 "gemini-embedding-001",
                 new float[] {1f, 0f, 0f},
@@ -157,6 +166,56 @@ class CardSearchRepositoryImplIntegrationTest {
 
         assertEquals(1, result.getContent().size());
         assertEquals(textCard, result.getContent().getFirst().getId());
+    }
+
+    @Test
+    void searchHybridSummariesByUserIdAppliesCardTypeAndUpdatedAfterFilters() {
+        insertUser(1L, "admin");
+        UUID matchingCard = insertCard(
+                1L,
+                "Invoice follow up",
+                "Need action",
+                "Vendor correction pending",
+                CardType.FOLLOW_UP,
+                CardStatus.OPEN,
+                Instant.parse("2026-04-05T02:00:00Z")
+        );
+        insertEmbedding(matchingCard, "[1,0,0]");
+        UUID wrongTypeCard = insertCard(
+                1L,
+                "Invoice note",
+                "Need action",
+                "Vendor correction pending",
+                CardType.NOTE,
+                CardStatus.OPEN,
+                Instant.parse("2026-04-05T02:05:00Z")
+        );
+        insertEmbedding(wrongTypeCard, "[1,0,0]");
+        UUID tooOldCard = insertCard(
+                1L,
+                "Invoice archive",
+                "Need action",
+                "Vendor correction pending",
+                CardType.FOLLOW_UP,
+                CardStatus.OPEN,
+                Instant.parse("2026-04-05T00:05:00Z")
+        );
+        insertEmbedding(tooOldCard, "[1,0,0]");
+
+        Slice<CardSummaryProjection> result = repository.searchHybridSummariesByUserId(
+                "admin",
+                CardStatus.OPEN,
+                CardType.FOLLOW_UP,
+                Instant.parse("2026-04-05T01:00:00Z"),
+                Instant.parse("2026-04-05T03:00:00Z"),
+                "invoice",
+                "gemini-embedding-001",
+                new float[] {1f, 0f, 0f},
+                PageRequest.of(0, 10)
+        );
+
+        assertEquals(1, result.getContent().size());
+        assertEquals(matchingCard, result.getContent().getFirst().getId());
     }
 
     private void insertUser(long id, String userId) {
@@ -178,6 +237,10 @@ class CardSearchRepositoryImplIntegrationTest {
     }
 
     private UUID insertCard(long userFk, String title, String summary, String content, CardStatus status, Instant updatedAt) {
+        return insertCard(userFk, title, summary, content, CardType.FOLLOW_UP, status, updatedAt);
+    }
+
+    private UUID insertCard(long userFk, String title, String summary, String content, CardType cardType, CardStatus status, Instant updatedAt) {
         UUID id = UUID.randomUUID();
         jdbcTemplate.update(
                 """
@@ -189,7 +252,7 @@ class CardSearchRepositoryImplIntegrationTest {
                 title,
                 summary,
                 content,
-                CardType.FOLLOW_UP.name(),
+                cardType.name(),
                 status.name(),
                 CardPriority.MEDIUM.name(),
                 null,

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
@@ -17,6 +17,7 @@ import io.quintkard.quintkardapp.embedding.EmbeddingProperties;
 import io.quintkard.quintkardapp.embedding.EmbeddingService;
 import io.quintkard.quintkardapp.user.User;
 import io.quintkard.quintkardapp.user.UserRepository;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -91,13 +92,36 @@ class CardServiceImplTest {
     void listCardsWithoutQueryUsesRepositoryListPath() {
         @SuppressWarnings("unchecked")
         Slice<CardSummaryProjection> expectedSlice = new SliceImpl<>(List.of(mock(CardSummaryProjection.class)));
-        when(cardRepository.findSummariesByUserUserIdOrderByUpdatedAtDesc(eq("admin"), any(PageRequest.class)))
+        when(cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
+                eq("admin"),
+                eq(null),
+                eq(CardType.FOLLOW_UP),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
+                any(PageRequest.class)
+        ))
                 .thenReturn(expectedSlice);
 
-        Slice<CardSummaryProjection> result = cardService.listCards("admin", 0, 25, "   ", null);
+        Slice<CardSummaryProjection> result = cardService.listCards(
+                "admin",
+                0,
+                25,
+                "   ",
+                null,
+                CardType.FOLLOW_UP,
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
 
         assertSame(expectedSlice, result);
-        verify(cardRepository).findSummariesByUserUserIdOrderByUpdatedAtDesc(eq("admin"), eq(PageRequest.of(0, 25)));
+        verify(cardRepository).findSummariesByFiltersOrderByUpdatedAtDesc(
+                eq("admin"),
+                eq(null),
+                eq(CardType.FOLLOW_UP),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
+                eq(PageRequest.of(0, 25))
+        );
         verifyNoInteractions(embeddingService);
     }
 
@@ -110,6 +134,9 @@ class CardServiceImplTest {
         when(cardRepository.searchHybridSummariesByUserId(
                 eq("admin"),
                 eq(CardStatus.OPEN),
+                eq(CardType.FOLLOW_UP),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
                 eq("invoice follow up"),
                 eq("gemini-embedding-001"),
                 eq(embedding),
@@ -117,13 +144,25 @@ class CardServiceImplTest {
         )).thenReturn(expectedSlice);
 
         Slice<CardSummaryProjection> result =
-                cardService.listCards("admin", -2, 500, "  invoice follow up  ", CardStatus.OPEN);
+                cardService.listCards(
+                        "admin",
+                        -2,
+                        500,
+                        "  invoice follow up  ",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                );
 
         assertSame(expectedSlice, result);
         verify(embeddingService).embed("invoice follow up");
         verify(cardRepository).searchHybridSummariesByUserId(
                 eq("admin"),
                 eq(CardStatus.OPEN),
+                eq(CardType.FOLLOW_UP),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
                 eq("invoice follow up"),
                 eq("gemini-embedding-001"),
                 eq(embedding),
@@ -327,15 +366,25 @@ class CardServiceImplTest {
     void listCardsWithoutQueryAndStatusUsesStatusRepositoryPath() {
         @SuppressWarnings("unchecked")
         Slice<CardSummaryProjection> expectedSlice = new SliceImpl<>(List.of(mock(CardSummaryProjection.class)));
-        when(cardRepository.findSummariesByUserUserIdAndStatusOrderByUpdatedAtDesc(eq("admin"), eq(CardStatus.DONE), any(PageRequest.class)))
-                .thenReturn(expectedSlice);
-
-        Slice<CardSummaryProjection> result = cardService.listCards("admin", 0, -1, null, CardStatus.DONE);
-
-        assertSame(expectedSlice, result);
-        verify(cardRepository).findSummariesByUserUserIdAndStatusOrderByUpdatedAtDesc(
+        when(cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
                 eq("admin"),
                 eq(CardStatus.DONE),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(PageRequest.class)
+        ))
+                .thenReturn(expectedSlice);
+
+        Slice<CardSummaryProjection> result = cardService.listCards("admin", 0, -1, null, CardStatus.DONE, null, null, null);
+
+        assertSame(expectedSlice, result);
+        verify(cardRepository).findSummariesByFiltersOrderByUpdatedAtDesc(
+                eq("admin"),
+                eq(CardStatus.DONE),
+                eq(null),
+                eq(null),
+                eq(null),
                 eq(PageRequest.of(0, 20))
         );
         verifyNoInteractions(embeddingService);

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
@@ -26,9 +26,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class CardServiceImplTest {
@@ -90,37 +93,32 @@ class CardServiceImplTest {
 
     @Test
     void listCardsWithoutQueryUsesRepositoryListPath() {
-        @SuppressWarnings("unchecked")
-        Slice<CardSummaryProjection> expectedSlice = new SliceImpl<>(List.of(mock(CardSummaryProjection.class)));
-        when(cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
-                eq("admin"),
-                eq(null),
-                eq(CardType.FOLLOW_UP),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
+        Card entity = card("admin", UUID.randomUUID());
+        PageImpl<Card> expectedSlice = new PageImpl<>(List.of(entity));
+        when(cardRepository.findAll(
+                any(Specification.class),
                 any(PageRequest.class)
         ))
                 .thenReturn(expectedSlice);
 
         Slice<CardSummaryProjection> result = cardService.listCards(
-                "admin",
+                new CardFilter(
+                        "admin",
+                        "   ",
+                        null,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 0,
-                25,
-                "   ",
-                null,
-                CardType.FOLLOW_UP,
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                25
         );
 
-        assertSame(expectedSlice, result);
-        verify(cardRepository).findSummariesByFiltersOrderByUpdatedAtDesc(
-                eq("admin"),
-                eq(null),
-                eq(CardType.FOLLOW_UP),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
-                eq(PageRequest.of(0, 25))
+        assertEquals(1, result.getContent().size());
+        assertEquals(entity.getId(), result.getContent().getFirst().getId());
+        verify(cardRepository).findAll(
+                any(Specification.class),
+                eq(PageRequest.of(0, 25, Sort.by(Sort.Direction.DESC, "updatedAt")))
         );
         verifyNoInteractions(embeddingService);
     }
@@ -131,13 +129,15 @@ class CardServiceImplTest {
         @SuppressWarnings("unchecked")
         Slice<CardSummaryProjection> expectedSlice = new SliceImpl<>(List.of(mock(CardSummaryProjection.class)));
         when(embeddingService.embed("invoice follow up")).thenReturn(embedding);
-        when(cardRepository.searchHybridSummariesByUserId(
-                eq("admin"),
-                eq(CardStatus.OPEN),
-                eq(CardType.FOLLOW_UP),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
-                eq("invoice follow up"),
+        when(cardRepository.searchHybridSummaries(
+                eq(new CardFilter(
+                        "admin",
+                        "invoice follow up",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                )),
                 eq("gemini-embedding-001"),
                 eq(embedding),
                 any(PageRequest.class)
@@ -145,28 +145,32 @@ class CardServiceImplTest {
 
         Slice<CardSummaryProjection> result =
                 cardService.listCards(
-                        "admin",
+                        new CardFilter(
+                                "admin",
+                                "  invoice follow up  ",
+                                CardStatus.OPEN,
+                                CardType.FOLLOW_UP,
+                                Instant.parse("2026-04-05T00:00:00Z"),
+                                Instant.parse("2026-04-06T00:00:00Z")
+                        ),
                         -2,
-                        500,
-                        "  invoice follow up  ",
-                        CardStatus.OPEN,
-                        CardType.FOLLOW_UP,
-                        Instant.parse("2026-04-05T00:00:00Z"),
-                        Instant.parse("2026-04-06T00:00:00Z")
+                        500
                 );
 
         assertSame(expectedSlice, result);
         verify(embeddingService).embed("invoice follow up");
-        verify(cardRepository).searchHybridSummariesByUserId(
-                eq("admin"),
-                eq(CardStatus.OPEN),
-                eq(CardType.FOLLOW_UP),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
-                eq("invoice follow up"),
+        verify(cardRepository).searchHybridSummaries(
+                eq(new CardFilter(
+                        "admin",
+                        "invoice follow up",
+                        CardStatus.OPEN,
+                        CardType.FOLLOW_UP,
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                )),
                 eq("gemini-embedding-001"),
                 eq(embedding),
-                eq(PageRequest.of(0, 100))
+                eq(PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "updatedAt")))
         );
     }
 
@@ -364,28 +368,25 @@ class CardServiceImplTest {
 
     @Test
     void listCardsWithoutQueryAndStatusUsesStatusRepositoryPath() {
-        @SuppressWarnings("unchecked")
-        Slice<CardSummaryProjection> expectedSlice = new SliceImpl<>(List.of(mock(CardSummaryProjection.class)));
-        when(cardRepository.findSummariesByFiltersOrderByUpdatedAtDesc(
-                eq("admin"),
-                eq(CardStatus.DONE),
-                eq(null),
-                eq(null),
-                eq(null),
+        Card entity = card("admin", UUID.randomUUID());
+        PageImpl<Card> expectedSlice = new PageImpl<>(List.of(entity));
+        when(cardRepository.findAll(
+                any(Specification.class),
                 any(PageRequest.class)
         ))
                 .thenReturn(expectedSlice);
 
-        Slice<CardSummaryProjection> result = cardService.listCards("admin", 0, -1, null, CardStatus.DONE, null, null, null);
+        Slice<CardSummaryProjection> result = cardService.listCards(
+                new CardFilter("admin", null, CardStatus.DONE, null, null, null),
+                0,
+                -1
+        );
 
-        assertSame(expectedSlice, result);
-        verify(cardRepository).findSummariesByFiltersOrderByUpdatedAtDesc(
-                eq("admin"),
-                eq(CardStatus.DONE),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(PageRequest.of(0, 20))
+        assertEquals(1, result.getContent().size());
+        assertEquals(entity.getId(), result.getContent().getFirst().getId());
+        verify(cardRepository).findAll(
+                any(Specification.class),
+                eq(PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "updatedAt")))
         );
         verifyNoInteractions(embeddingService);
     }

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardServiceImplTest.java
@@ -160,17 +160,17 @@ class CardServiceImplTest {
         assertSame(expectedSlice, result);
         verify(embeddingService).embed("invoice follow up");
         verify(cardRepository).searchHybridSummaries(
-                eq(new CardFilter(
+                new CardFilter(
                         "admin",
                         "invoice follow up",
                         CardStatus.OPEN,
                         CardType.FOLLOW_UP,
                         Instant.parse("2026-04-05T00:00:00Z"),
                         Instant.parse("2026-04-06T00:00:00Z")
-                )),
-                eq("gemini-embedding-001"),
-                eq(embedding),
-                eq(PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "updatedAt")))
+                ),
+                "gemini-embedding-001",
+                embedding,
+                PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "updatedAt"))
         );
     }
 

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageControllerTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -49,17 +50,19 @@ class MessageControllerTest {
         when(summary.getIngestedAt()).thenReturn(Instant.parse("2026-04-05T12:00:00Z"));
         when(summary.getSourceCreatedAt()).thenReturn(Instant.parse("2026-04-05T11:55:00Z"));
         when(messageService.listMessages(
-                "admin",
+                new MessageFilter(
+                        "admin",
+                        "invoice",
+                        MessageStatus.PENDING,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 0,
-                20,
-                "invoice",
-                MessageStatus.PENDING,
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                20
         ))
-                .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(0, 20), false));
+                .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(0, 20, Sort.by("ingestedAt").descending()), false));
 
         mockMvc.perform(authorized(get("/api/messages"))
                         .param("query", "invoice")
@@ -73,15 +76,17 @@ class MessageControllerTest {
                 .andExpect(jsonPath("$.items[0].sourceService").value("gmail"));
 
         verify(messageService).listMessages(
-                "admin",
+                new MessageFilter(
+                        "admin",
+                        "invoice",
+                        MessageStatus.PENDING,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 0,
-                20,
-                "invoice",
-                MessageStatus.PENDING,
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                20
         );
     }
 

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageControllerTest.java
@@ -48,17 +48,41 @@ class MessageControllerTest {
         when(summary.getSummary()).thenReturn("Invoice follow up");
         when(summary.getIngestedAt()).thenReturn(Instant.parse("2026-04-05T12:00:00Z"));
         when(summary.getSourceCreatedAt()).thenReturn(Instant.parse("2026-04-05T11:55:00Z"));
-        when(messageService.listMessages("admin", 0, 20, "invoice", MessageStatus.PENDING))
+        when(messageService.listMessages(
+                "admin",
+                0,
+                20,
+                "invoice",
+                MessageStatus.PENDING,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        ))
                 .thenReturn(new SliceImpl<>(java.util.List.of(summary), PageRequest.of(0, 20), false));
 
         mockMvc.perform(authorized(get("/api/messages"))
                         .param("query", "invoice")
-                        .param("status", "PENDING"))
+                        .param("status", "PENDING")
+                        .param("sourceService", "gmail")
+                        .param("messageType", "EMAIL")
+                        .param("ingestedAfter", "2026-04-05T00:00:00Z")
+                        .param("ingestedBefore", "2026-04-06T00:00:00Z"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items[0].id").value(messageId.toString()))
                 .andExpect(jsonPath("$.items[0].sourceService").value("gmail"));
 
-        verify(messageService).listMessages("admin", 0, 20, "invoice", MessageStatus.PENDING);
+        verify(messageService).listMessages(
+                "admin",
+                0,
+                20,
+                "invoice",
+                MessageStatus.PENDING,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageIngestionControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageIngestionControllerTest.java
@@ -37,7 +37,7 @@ class MessageIngestionControllerTest {
     @Test
     void ingestMessageUsesAuthenticatedUser() throws Exception {
         Message message = message(UUID.randomUUID(), "gmail", "EMAIL");
-        when(messageIngestionService.ingestMessage(eq("admin"), eq(new MessageEnvelope(
+        when(messageIngestionService.ingestMessage("admin", new MessageEnvelope(
                 "gmail",
                 "ext-1",
                 "EMAIL",
@@ -45,7 +45,7 @@ class MessageIngestionControllerTest {
                 Map.of("threadId", "t-1"),
                 Map.of("priority", "high"),
                 Instant.parse("2026-04-05T11:55:00Z")
-        )))).thenReturn(message);
+        ))).thenReturn(message);
 
         mockMvc.perform(authorized(post("/api/messages/ingest"))
                         .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
@@ -65,7 +65,7 @@ class MessageIngestionControllerTest {
                 .andExpect(jsonPath("$.sourceService").value("gmail"))
                 .andExpect(jsonPath("$.messageType").value("EMAIL"));
 
-        verify(messageIngestionService).ingestMessage(eq("admin"), eq(new MessageEnvelope(
+        verify(messageIngestionService).ingestMessage("admin", new MessageEnvelope(
                 "gmail",
                 "ext-1",
                 "EMAIL",
@@ -73,7 +73,7 @@ class MessageIngestionControllerTest {
                 Map.of("threadId", "t-1"),
                 Map.of("priority", "high"),
                 Instant.parse("2026-04-05T11:55:00Z")
-        )));
+        ));
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageIngestionControllerTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageIngestionControllerTest.java
@@ -1,0 +1,132 @@
+package io.quintkard.quintkardapp.message;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.quintkard.quintkardapp.user.User;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class MessageIngestionControllerTest {
+
+    private MessageIngestionService messageIngestionService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        messageIngestionService = mock(MessageIngestionService.class);
+        MessageIngestionController controller = new MessageIngestionController(messageIngestionService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void ingestMessageUsesAuthenticatedUser() throws Exception {
+        Message message = message(UUID.randomUUID(), "gmail", "EMAIL");
+        when(messageIngestionService.ingestMessage(eq("admin"), eq(new MessageEnvelope(
+                "gmail",
+                "ext-1",
+                "EMAIL",
+                "Follow up on invoice",
+                Map.of("threadId", "t-1"),
+                Map.of("priority", "high"),
+                Instant.parse("2026-04-05T11:55:00Z")
+        )))).thenReturn(message);
+
+        mockMvc.perform(authorized(post("/api/messages/ingest"))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "sourceService": "gmail",
+                                  "externalMessageId": "ext-1",
+                                  "messageType": "EMAIL",
+                                  "payload": "Follow up on invoice",
+                                  "metadata": {"threadId": "t-1"},
+                                  "details": {"priority": "high"},
+                                  "sourceCreatedAt": "2026-04-05T11:55:00Z"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value("admin"))
+                .andExpect(jsonPath("$.sourceService").value("gmail"))
+                .andExpect(jsonPath("$.messageType").value("EMAIL"));
+
+        verify(messageIngestionService).ingestMessage(eq("admin"), eq(new MessageEnvelope(
+                "gmail",
+                "ext-1",
+                "EMAIL",
+                "Follow up on invoice",
+                Map.of("threadId", "t-1"),
+                Map.of("priority", "high"),
+                Instant.parse("2026-04-05T11:55:00Z")
+        )));
+    }
+
+    @Test
+    void ingestMessagesReturnsCreatedBatchResponse() throws Exception {
+        when(messageIngestionService.ingestMessages(eq("admin"), anyList())).thenReturn(List.of(
+                message(UUID.randomUUID(), "gmail", "EMAIL"),
+                message(UUID.randomUUID(), "slack", "CHANNEL_MESSAGE")
+        ));
+
+        mockMvc.perform(authorized(post("/api/messages/ingest/batch"))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                [
+                                  {
+                                    "sourceService": "gmail",
+                                    "externalMessageId": "ext-1",
+                                    "messageType": "EMAIL",
+                                    "payload": "Follow up on invoice"
+                                  },
+                                  {
+                                    "sourceService": "slack",
+                                    "externalMessageId": "ext-2",
+                                    "messageType": "CHANNEL_MESSAGE",
+                                    "payload": "Reminder in channel"
+                                  }
+                                ]
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$[0].sourceService").value("gmail"))
+                .andExpect(jsonPath("$[1].sourceService").value("slack"));
+
+        verify(messageIngestionService).ingestMessages(eq("admin"), anyList());
+    }
+
+    private MockHttpServletRequestBuilder authorized(MockHttpServletRequestBuilder builder) {
+        return builder.principal(new TestingAuthenticationToken("admin", "password"));
+    }
+
+    private Message message(UUID id, String sourceService, String messageType) {
+        Message message = new Message(
+                new User("admin", "Admin", "admin@example.com", "hash", false),
+                sourceService,
+                "ext-" + id,
+                messageType,
+                MessageStatus.PENDING,
+                "Payload",
+                "Summary",
+                Map.of(),
+                Map.of(),
+                Instant.parse("2026-04-05T12:00:00Z"),
+                Instant.parse("2026-04-05T11:55:00Z")
+        );
+        ReflectionTestUtils.setField(message, "id", id);
+        return message;
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImplIntegrationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImplIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImplIntegrationTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImplIntegrationTest.java
@@ -1,0 +1,221 @@
+package io.quintkard.quintkardapp.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers(disabledWithoutDocker = true)
+class MessageSearchRepositoryImplIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
+            DockerImageName.parse("pgvector/pgvector:pg16").asCompatibleSubstituteFor("postgres")
+    );
+
+    private JdbcTemplate jdbcTemplate;
+    private MessageSearchRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource(
+                POSTGRES.getJdbcUrl(),
+                POSTGRES.getUsername(),
+                POSTGRES.getPassword()
+        );
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        repository = new MessageSearchRepositoryImpl(jdbcTemplate);
+
+        jdbcTemplate.execute("drop table if exists messages cascade");
+        jdbcTemplate.execute("drop table if exists users cascade");
+
+        jdbcTemplate.execute("""
+                create table users (
+                    id bigint primary key,
+                    user_id varchar(255) not null unique,
+                    display_name varchar(255) not null,
+                    email varchar(255) not null,
+                    password_hash varchar(255) not null,
+                    redaction_enabled boolean not null,
+                    created_at timestamptz not null,
+                    updated_at timestamptz not null
+                )
+                """);
+
+        jdbcTemplate.execute("""
+                create table messages (
+                    id uuid primary key,
+                    user_fk bigint not null references users(id),
+                    source_service varchar(255) not null,
+                    external_message_id varchar(255),
+                    message_type varchar(255) not null,
+                    status varchar(255) not null,
+                    payload text not null,
+                    summary varchar(280),
+                    metadata_json jsonb,
+                    details_json jsonb,
+                    ingested_at timestamptz not null,
+                    source_created_at timestamptz
+                )
+                """);
+    }
+
+    @Test
+    void searchSummariesFiltersByUserAndStatus() {
+        insertUser(1L, "admin");
+        insertUser(2L, "other");
+        UUID matchingMessage = insertMessage(
+                1L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Follow up on invoice from last August",
+                Instant.parse("2026-04-05T12:00:00Z")
+        );
+        insertMessage(
+                1L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.SUCCESS,
+                "Follow up on invoice from last August",
+                Instant.parse("2026-04-05T12:05:00Z")
+        );
+        insertMessage(
+                2L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Follow up on invoice from last August",
+                Instant.parse("2026-04-05T12:10:00Z")
+        );
+
+        Slice<MessageSummaryProjection> result = repository.searchSummaries(
+                new MessageFilter("admin", "invoice", MessageStatus.PENDING, null, null, null, null),
+                PageRequest.of(0, 10)
+        );
+
+        assertEquals(1, result.getContent().size());
+        assertEquals(matchingMessage, result.getContent().getFirst().getId());
+    }
+
+    @Test
+    void searchSummariesAppliesStructuredFiltersAndPagination() {
+        insertUser(1L, "admin");
+        UUID firstMatch = insertMessage(
+                1L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Account update and invoice review",
+                Instant.parse("2026-04-05T12:00:00Z")
+        );
+        UUID secondMatch = insertMessage(
+                1L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Invoice account update required",
+                Instant.parse("2026-04-05T12:10:00Z")
+        );
+        insertMessage(
+                1L,
+                "slack",
+                "CHANNEL_MESSAGE",
+                MessageStatus.PENDING,
+                "Invoice account update required",
+                Instant.parse("2026-04-05T12:20:00Z")
+        );
+        insertMessage(
+                1L,
+                "gmail",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Invoice account update required",
+                Instant.parse("2026-04-05T11:00:00Z")
+        );
+
+        MessageFilter filter = new MessageFilter(
+                "admin",
+                "account update",
+                MessageStatus.PENDING,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T11:30:00Z"),
+                Instant.parse("2026-04-05T12:30:00Z")
+        );
+
+        Slice<MessageSummaryProjection> firstPage = repository.searchSummaries(filter, PageRequest.of(0, 1));
+        Slice<MessageSummaryProjection> secondPage = repository.searchSummaries(filter, PageRequest.of(1, 1));
+
+        assertEquals(1, firstPage.getContent().size());
+        assertTrue(firstPage.hasNext());
+        assertEquals(secondMatch, firstPage.getContent().getFirst().getId());
+
+        assertEquals(1, secondPage.getContent().size());
+        assertEquals(firstMatch, secondPage.getContent().getFirst().getId());
+    }
+
+    private void insertUser(long id, String userId) {
+        Timestamp now = Timestamp.from(Instant.parse("2026-04-05T00:00:00Z"));
+        jdbcTemplate.update(
+                """
+                insert into users (id, user_id, display_name, email, password_hash, redaction_enabled, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                id,
+                userId,
+                userId,
+                userId + "@example.com",
+                "hash",
+                false,
+                now,
+                now
+        );
+    }
+
+    private UUID insertMessage(
+            long userFk,
+            String sourceService,
+            String messageType,
+            MessageStatus status,
+            String payload,
+            Instant ingestedAt
+    ) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                insert into messages (
+                    id, user_fk, source_service, external_message_id, message_type, status,
+                    payload, summary, metadata_json, details_json, ingested_at, source_created_at
+                )
+                values (?, ?, ?, ?, ?, ?, ?, ?, cast(? as jsonb), cast(? as jsonb), ?, ?)
+                """,
+                id,
+                userFk,
+                sourceService,
+                "ext-" + id,
+                messageType,
+                status.name(),
+                payload,
+                payload.length() > 40 ? payload.substring(0, 40) : payload,
+                "{}",
+                "{}",
+                Timestamp.from(ingestedAt),
+                Timestamp.from(ingestedAt.minusSeconds(60))
+        );
+        return id;
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageServiceImplTest.java
@@ -61,28 +61,76 @@ class MessageServiceImplTest {
     void listMessagesWithoutQueryUsesDefaultRepositoryPath() {
         @SuppressWarnings("unchecked")
         Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.findSummariesByUserUserIdOrderByIngestedAtDesc(eq("admin"), any(PageRequest.class)))
+        when(messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
+                eq("admin"),
+                eq(null),
+                eq("gmail"),
+                eq("EMAIL"),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
+                any(PageRequest.class)
+        ))
                 .thenReturn(expected);
 
-        Slice<MessageSummaryProjection> result = service.listMessages("admin", 0, 25, "   ", null);
+        Slice<MessageSummaryProjection> result = service.listMessages(
+                "admin",
+                0,
+                25,
+                "   ",
+                null,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
 
         assertSame(expected, result);
-        verify(messageRepository).findSummariesByUserUserIdOrderByIngestedAtDesc("admin", PageRequest.of(0, 25));
+        verify(messageRepository).findSummariesByFiltersOrderByIngestedAtDesc(
+                "admin",
+                null,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z"),
+                PageRequest.of(0, 25)
+        );
     }
 
     @Test
     void listMessagesWithoutQueryAndWithStatusUsesStatusRepositoryPath() {
         @SuppressWarnings("unchecked")
         Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.findSummariesByUserUserIdAndStatusOrderByIngestedAtDesc(eq("admin"), eq(MessageStatus.FAILED), any(PageRequest.class)))
+        when(messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
+                eq("admin"),
+                eq(MessageStatus.FAILED),
+                eq("slack"),
+                eq("CHANNEL_MESSAGE"),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
+                any(PageRequest.class)
+        ))
                 .thenReturn(expected);
 
-        Slice<MessageSummaryProjection> result = service.listMessages("admin", 0, -1, null, MessageStatus.FAILED);
+        Slice<MessageSummaryProjection> result = service.listMessages(
+                "admin",
+                0,
+                -1,
+                null,
+                MessageStatus.FAILED,
+                " slack ",
+                " CHANNEL_MESSAGE ",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
 
         assertSame(expected, result);
-        verify(messageRepository).findSummariesByUserUserIdAndStatusOrderByIngestedAtDesc(
+        verify(messageRepository).findSummariesByFiltersOrderByIngestedAtDesc(
                 "admin",
                 MessageStatus.FAILED,
+                "slack",
+                "CHANNEL_MESSAGE",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z"),
                 PageRequest.of(0, 20)
         );
     }
@@ -91,13 +139,41 @@ class MessageServiceImplTest {
     void listMessagesWithQueryUsesSearchRepositoryPath() {
         @SuppressWarnings("unchecked")
         Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.searchSummariesByUserId(eq("admin"), eq("SUCCESS"), eq("invoice"), any(PageRequest.class)))
+        when(messageRepository.searchSummariesByUserId(
+                eq("admin"),
+                eq("SUCCESS"),
+                eq("gmail"),
+                eq("EMAIL"),
+                eq(Instant.parse("2026-04-05T00:00:00Z")),
+                eq(Instant.parse("2026-04-06T00:00:00Z")),
+                eq("invoice"),
+                any(PageRequest.class)
+        ))
                 .thenReturn(expected);
 
-        Slice<MessageSummaryProjection> result = service.listMessages("admin", -5, 500, "  invoice  ", MessageStatus.SUCCESS);
+        Slice<MessageSummaryProjection> result = service.listMessages(
+                "admin",
+                -5,
+                500,
+                "  invoice  ",
+                MessageStatus.SUCCESS,
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z")
+        );
 
         assertSame(expected, result);
-        verify(messageRepository).searchSummariesByUserId("admin", "SUCCESS", "invoice", PageRequest.of(0, 100));
+        verify(messageRepository).searchSummariesByUserId(
+                "admin",
+                "SUCCESS",
+                "gmail",
+                "EMAIL",
+                Instant.parse("2026-04-05T00:00:00Z"),
+                Instant.parse("2026-04-06T00:00:00Z"),
+                "invoice",
+                PageRequest.of(0, 100)
+        );
     }
 
     @Test

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageServiceImplTest.java
@@ -17,9 +17,12 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MessageServiceImplTest {
@@ -59,79 +62,63 @@ class MessageServiceImplTest {
 
     @Test
     void listMessagesWithoutQueryUsesDefaultRepositoryPath() {
-        @SuppressWarnings("unchecked")
-        Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
-                eq("admin"),
-                eq(null),
-                eq("gmail"),
-                eq("EMAIL"),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
+        Message expected = message(UUID.randomUUID(), MessageStatus.PENDING);
+        when(messageRepository.findAll(
+                any(Specification.class),
                 any(PageRequest.class)
         ))
-                .thenReturn(expected);
+                .thenReturn(new PageImpl<>(List.of(expected)));
 
         Slice<MessageSummaryProjection> result = service.listMessages(
-                "admin",
+                new MessageFilter(
+                        "admin",
+                        "   ",
+                        null,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 0,
-                25,
-                "   ",
-                null,
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                25
         );
 
-        assertSame(expected, result);
-        verify(messageRepository).findSummariesByFiltersOrderByIngestedAtDesc(
-                "admin",
-                null,
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z"),
-                PageRequest.of(0, 25)
+        assertEquals(1, result.getContent().size());
+        assertEquals(expected.getId(), result.getContent().getFirst().getId());
+        verify(messageRepository).findAll(
+                any(Specification.class),
+                eq(PageRequest.of(0, 25, Sort.by(Sort.Direction.DESC, "ingestedAt")))
         );
     }
 
     @Test
     void listMessagesWithoutQueryAndWithStatusUsesStatusRepositoryPath() {
-        @SuppressWarnings("unchecked")
-        Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.findSummariesByFiltersOrderByIngestedAtDesc(
-                eq("admin"),
-                eq(MessageStatus.FAILED),
-                eq("slack"),
-                eq("CHANNEL_MESSAGE"),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
+        Message expected = message(UUID.randomUUID(), MessageStatus.FAILED);
+        when(messageRepository.findAll(
+                any(Specification.class),
                 any(PageRequest.class)
         ))
-                .thenReturn(expected);
+                .thenReturn(new PageImpl<>(List.of(expected)));
 
         Slice<MessageSummaryProjection> result = service.listMessages(
-                "admin",
+                new MessageFilter(
+                        "admin",
+                        null,
+                        MessageStatus.FAILED,
+                        " slack ",
+                        " CHANNEL_MESSAGE ",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 0,
-                -1,
-                null,
-                MessageStatus.FAILED,
-                " slack ",
-                " CHANNEL_MESSAGE ",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                -1
         );
 
-        assertSame(expected, result);
-        verify(messageRepository).findSummariesByFiltersOrderByIngestedAtDesc(
-                "admin",
-                MessageStatus.FAILED,
-                "slack",
-                "CHANNEL_MESSAGE",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z"),
-                PageRequest.of(0, 20)
+        assertEquals(1, result.getContent().size());
+        assertEquals(expected.getId(), result.getContent().getFirst().getId());
+        verify(messageRepository).findAll(
+                any(Specification.class),
+                eq(PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "ingestedAt")))
         );
     }
 
@@ -139,40 +126,46 @@ class MessageServiceImplTest {
     void listMessagesWithQueryUsesSearchRepositoryPath() {
         @SuppressWarnings("unchecked")
         Slice<MessageSummaryProjection> expected = new SliceImpl<>(List.of(mock(MessageSummaryProjection.class)));
-        when(messageRepository.searchSummariesByUserId(
-                eq("admin"),
-                eq("SUCCESS"),
-                eq("gmail"),
-                eq("EMAIL"),
-                eq(Instant.parse("2026-04-05T00:00:00Z")),
-                eq(Instant.parse("2026-04-06T00:00:00Z")),
-                eq("invoice"),
+        when(messageRepository.searchSummaries(
+                eq(new MessageFilter(
+                        "admin",
+                        "invoice",
+                        MessageStatus.SUCCESS,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                )),
                 any(PageRequest.class)
         ))
                 .thenReturn(expected);
 
         Slice<MessageSummaryProjection> result = service.listMessages(
-                "admin",
+                new MessageFilter(
+                        "admin",
+                        "  invoice  ",
+                        MessageStatus.SUCCESS,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
                 -5,
-                500,
-                "  invoice  ",
-                MessageStatus.SUCCESS,
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z")
+                500
         );
 
         assertSame(expected, result);
-        verify(messageRepository).searchSummariesByUserId(
-                "admin",
-                "SUCCESS",
-                "gmail",
-                "EMAIL",
-                Instant.parse("2026-04-05T00:00:00Z"),
-                Instant.parse("2026-04-06T00:00:00Z"),
-                "invoice",
-                PageRequest.of(0, 100)
+        verify(messageRepository).searchSummaries(
+                new MessageFilter(
+                        "admin",
+                        "invoice",
+                        MessageStatus.SUCCESS,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                ),
+                PageRequest.of(0, 100, Sort.by(Sort.Direction.DESC, "ingestedAt"))
         );
     }
 

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSpecificationsTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/message/MessageSpecificationsTest.java
@@ -1,0 +1,110 @@
+package io.quintkard.quintkardapp.message;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+class MessageSpecificationsTest {
+
+    @Test
+    void fromFilterAppliesAllConfiguredPredicates() {
+        @SuppressWarnings("unchecked")
+        Root<Message> root = mock(Root.class);
+        @SuppressWarnings("unchecked")
+        CriteriaQuery<Object> query = mock(CriteriaQuery.class);
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        @SuppressWarnings("unchecked")
+        Join<Object, Object> userJoin = mock(Join.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> userIdPath = mock(Path.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> statusPath = mock(Path.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> sourceServicePath = mock(Path.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> messageTypePath = mock(Path.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> ingestedAtPath = mock(Path.class);
+
+        Predicate userPredicate = mock(Predicate.class);
+        Predicate statusPredicate = mock(Predicate.class);
+        Predicate sourceServicePredicate = mock(Predicate.class);
+        Predicate messageTypePredicate = mock(Predicate.class);
+        Predicate ingestedAfterPredicate = mock(Predicate.class);
+        Predicate ingestedBeforePredicate = mock(Predicate.class);
+        when(root.join("user")).thenReturn(userJoin);
+        when(userJoin.get("userId")).thenReturn(userIdPath);
+        when(root.get("status")).thenReturn(statusPath);
+        when(root.get("sourceService")).thenReturn(sourceServicePath);
+        when(root.get("messageType")).thenReturn(messageTypePath);
+        when(root.get("ingestedAt")).thenReturn(ingestedAtPath);
+
+        when(criteriaBuilder.equal(userIdPath, "admin")).thenReturn(userPredicate);
+        when(criteriaBuilder.equal(statusPath, MessageStatus.PENDING)).thenReturn(statusPredicate);
+        when(criteriaBuilder.equal(sourceServicePath, "gmail")).thenReturn(sourceServicePredicate);
+        when(criteriaBuilder.equal(messageTypePath, "EMAIL")).thenReturn(messageTypePredicate);
+        when(criteriaBuilder.greaterThanOrEqualTo((Path) ingestedAtPath, Instant.parse("2026-04-05T00:00:00Z")))
+                .thenReturn(ingestedAfterPredicate);
+        when(criteriaBuilder.lessThanOrEqualTo((Path) ingestedAtPath, Instant.parse("2026-04-06T00:00:00Z")))
+                .thenReturn(ingestedBeforePredicate);
+
+        Specification<Message> specification = MessageSpecifications.fromFilter(
+                new MessageFilter(
+                        "admin",
+                        "invoice",
+                        MessageStatus.PENDING,
+                        "gmail",
+                        "EMAIL",
+                        Instant.parse("2026-04-05T00:00:00Z"),
+                        Instant.parse("2026-04-06T00:00:00Z")
+                )
+        );
+
+        specification.toPredicate(root, query, criteriaBuilder);
+
+        verify(criteriaBuilder).equal(userIdPath, "admin");
+        verify(criteriaBuilder).equal(statusPath, MessageStatus.PENDING);
+        verify(criteriaBuilder).equal(sourceServicePath, "gmail");
+        verify(criteriaBuilder).equal(messageTypePath, "EMAIL");
+        verify(criteriaBuilder).greaterThanOrEqualTo((Path) ingestedAtPath, Instant.parse("2026-04-05T00:00:00Z"));
+        verify(criteriaBuilder).lessThanOrEqualTo((Path) ingestedAtPath, Instant.parse("2026-04-06T00:00:00Z"));
+    }
+
+    @Test
+    void fromFilterWithOnlyRequiredUserPredicateSkipsOptionalFilters() {
+        @SuppressWarnings("unchecked")
+        Root<Message> root = mock(Root.class);
+        @SuppressWarnings("unchecked")
+        CriteriaQuery<Object> query = mock(CriteriaQuery.class);
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        @SuppressWarnings("unchecked")
+        Join<Object, Object> userJoin = mock(Join.class);
+        @SuppressWarnings("unchecked")
+        Path<Object> userIdPath = mock(Path.class);
+        Predicate userPredicate = mock(Predicate.class);
+
+        when(root.join("user")).thenReturn(userJoin);
+        when(userJoin.get("userId")).thenReturn(userIdPath);
+        when(criteriaBuilder.equal(userIdPath, "admin")).thenReturn(userPredicate);
+
+        Specification<Message> specification = MessageSpecifications.fromFilter(
+                new MessageFilter("admin", null, null, null, null, null, null)
+        );
+
+        Predicate predicate = specification.toPredicate(root, query, criteriaBuilder);
+
+        assertSame(userPredicate, predicate);
+        verify(root).join("user");
+    }
+}

--- a/quintkard-ui/app/cards/page.tsx
+++ b/quintkard-ui/app/cards/page.tsx
@@ -49,6 +49,19 @@ function createEmptyForm(): CardRequest {
   };
 }
 
+function toInstantParam(value: string) {
+  if (!value) {
+    return "";
+  }
+
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return "";
+  }
+
+  return new Date(timestamp).toISOString();
+}
+
 export default function CardsPage() {
   const [cards, setCards] = useState<CardListItem[]>([]);
   const [selectedCard, setSelectedCard] = useState<CardResponse | null>(null);
@@ -59,6 +72,9 @@ export default function CardsPage() {
   const [mutating, setMutating] = useState(false);
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+  const [cardTypeFilter, setCardTypeFilter] = useState("");
+  const [updatedAfterFilter, setUpdatedAfterFilter] = useState("");
+  const [updatedBeforeFilter, setUpdatedBeforeFilter] = useState("");
   const [page, setPage] = useState(0);
   const [hasNext, setHasNext] = useState(false);
   const [error, setError] = useState("");
@@ -79,6 +95,20 @@ export default function CardsPage() {
 
     if (statusFilter) {
       params.set("status", statusFilter);
+    }
+
+    if (cardTypeFilter) {
+      params.set("cardType", cardTypeFilter);
+    }
+
+    const updatedAfterParam = toInstantParam(updatedAfterFilter);
+    if (updatedAfterParam) {
+      params.set("updatedAfter", updatedAfterParam);
+    }
+
+    const updatedBeforeParam = toInstantParam(updatedBeforeFilter);
+    if (updatedBeforeParam) {
+      params.set("updatedBefore", updatedBeforeParam);
     }
 
     try {
@@ -316,6 +346,40 @@ export default function CardsPage() {
                       </option>
                     ))}
                   </select>
+                </label>
+
+                <label className="field">
+                  <span>Card type</span>
+                  <select
+                    className="select"
+                    value={cardTypeFilter}
+                    onChange={(event) => setCardTypeFilter(event.target.value)}
+                  >
+                    <option value="">All</option>
+                    {CARD_TYPES.map((cardType) => (
+                      <option key={cardType} value={cardType}>
+                        {cardType}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="field">
+                  <span>Updated after</span>
+                  <input
+                    type="datetime-local"
+                    value={updatedAfterFilter}
+                    onChange={(event) => setUpdatedAfterFilter(event.target.value)}
+                  />
+                </label>
+
+                <label className="field">
+                  <span>Updated before</span>
+                  <input
+                    type="datetime-local"
+                    value={updatedBeforeFilter}
+                    onChange={(event) => setUpdatedBeforeFilter(event.target.value)}
+                  />
                 </label>
               </div>
 

--- a/quintkard-ui/app/messages/page.tsx
+++ b/quintkard-ui/app/messages/page.tsx
@@ -27,6 +27,19 @@ function buildHeaders() {
   return headers;
 }
 
+function toInstantParam(value: string) {
+  if (!value) {
+    return "";
+  }
+
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) {
+    return "";
+  }
+
+  return new Date(timestamp).toISOString();
+}
+
 export default function MessagesPage() {
   const [messages, setMessages] = useState<MessageListItem[]>([]);
   const [selectedMessage, setSelectedMessage] = useState<MessageResponse | null>(null);
@@ -36,12 +49,16 @@ export default function MessagesPage() {
   const [mutating, setMutating] = useState(false);
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+  const [sourceServiceFilter, setSourceServiceFilter] = useState("");
+  const [messageTypeFilter, setMessageTypeFilter] = useState("");
+  const [ingestedAfterFilter, setIngestedAfterFilter] = useState("");
+  const [ingestedBeforeFilter, setIngestedBeforeFilter] = useState("");
   const [page, setPage] = useState(0);
   const [hasNext, setHasNext] = useState(false);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const [sourceService, setSourceService] = useState("gmail");
-  const [messageType, setMessageType] = useState("email");
+  const [ingestSourceService, setIngestSourceService] = useState("gmail");
+  const [ingestMessageType, setIngestMessageType] = useState("email");
   const [externalMessageId, setExternalMessageId] = useState("");
   const [payload, setPayload] = useState("");
 
@@ -60,6 +77,24 @@ export default function MessagesPage() {
 
     if (statusFilter) {
       params.set("status", statusFilter);
+    }
+
+    if (sourceServiceFilter.trim()) {
+      params.set("sourceService", sourceServiceFilter.trim());
+    }
+
+    if (messageTypeFilter.trim()) {
+      params.set("messageType", messageTypeFilter.trim());
+    }
+
+    const ingestedAfterParam = toInstantParam(ingestedAfterFilter);
+    if (ingestedAfterParam) {
+      params.set("ingestedAfter", ingestedAfterParam);
+    }
+
+    const ingestedBeforeParam = toInstantParam(ingestedBeforeFilter);
+    if (ingestedBeforeParam) {
+      params.set("ingestedBefore", ingestedBeforeParam);
     }
 
     try {
@@ -203,9 +238,9 @@ export default function MessagesPage() {
         method: "POST",
         headers: buildHeaders(),
         body: JSON.stringify({
-          sourceService,
+          sourceService: ingestSourceService,
           externalMessageId: externalMessageId || null,
-          messageType,
+          messageType: ingestMessageType,
           payload,
           metadata: null,
           details: null,
@@ -271,6 +306,42 @@ export default function MessagesPage() {
                       </option>
                     ))}
                   </select>
+                </label>
+
+                <label className="field">
+                  <span>Source service</span>
+                  <input
+                    placeholder="gmail"
+                    value={sourceServiceFilter}
+                    onChange={(event) => setSourceServiceFilter(event.target.value)}
+                  />
+                </label>
+
+                <label className="field">
+                  <span>Message type</span>
+                  <input
+                    placeholder="EMAIL"
+                    value={messageTypeFilter}
+                    onChange={(event) => setMessageTypeFilter(event.target.value)}
+                  />
+                </label>
+
+                <label className="field">
+                  <span>Ingested after</span>
+                  <input
+                    type="datetime-local"
+                    value={ingestedAfterFilter}
+                    onChange={(event) => setIngestedAfterFilter(event.target.value)}
+                  />
+                </label>
+
+                <label className="field">
+                  <span>Ingested before</span>
+                  <input
+                    type="datetime-local"
+                    value={ingestedBeforeFilter}
+                    onChange={(event) => setIngestedBeforeFilter(event.target.value)}
+                  />
                 </label>
               </div>
 
@@ -415,12 +486,18 @@ export default function MessagesPage() {
                 <div className="form-grid">
                   <label className="field">
                     <span>Source service</span>
-                    <input value={sourceService} onChange={(event) => setSourceService(event.target.value)} />
+                    <input
+                      value={ingestSourceService}
+                      onChange={(event) => setIngestSourceService(event.target.value)}
+                    />
                   </label>
 
                   <label className="field">
                     <span>Message type</span>
-                    <input value={messageType} onChange={(event) => setMessageType(event.target.value)} />
+                    <input
+                      value={ingestMessageType}
+                      onChange={(event) => setIngestMessageType(event.target.value)}
+                    />
                   </label>
                 </div>
 

--- a/quintkard-ui/next-env.d.ts
+++ b/quintkard-ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #10

Summary:
This PR adds stronger filtering support for cards and messages across the backend and UI.

Changes:
- add card filters for status, card type, updatedAfter, and updatedBefore
- add message filters for status, source service, message type, ingestedAfter, and ingestedBefore
- apply the new filters to both normal list queries and card hybrid search
- add Flyway V2 indexes to support the new filtering paths
- update the cards and messages UI to expose the new filters
- extend controller, service, repository, and integration tests for the new behavior
