### PR TITLE
Hotfix security vulnerabilities

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,183 @@
-Quintkard Non-Commercial License 1.0
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Copyright (c) 2026 Quintkard contributors
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to use,
-copy, modify, and distribute the Software, in whole or in part, for
-non-commercial purposes only, subject to the following conditions:
+1. Definitions.
 
-1. The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
 
-2. The Software may not be used, copied, modified, distributed, sublicensed,
-   sold, offered as a service, or otherwise exploited for commercial advantage
-   or monetary compensation without prior written permission from the copyright
-   holder.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
 
-3. Any distribution of modified versions of the Software must clearly indicate
-   that changes were made.
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-4. This license does not grant any rights in trademarks, service marks, logos,
-   or branding associated with the Software.
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM,
-OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work constitutes
+direct or contributory patent infringement, then any patent licenses granted to
+You under this License for that Work shall terminate as of the date such
+litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole responsibility,
+not on behalf of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability incurred by, or
+claims asserted against, such Contributor by reason of your accepting any such
+warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+Copyright 2026 Quintkard contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The system is designed around user-level multi-tenancy: cards, messages, agents,
    Add support and test coverage for additional AI providers beyond the current Google GenAI setup.
 6. AI provider failure handling:
    Add more robust handling for AI provider failures, including retries.
+7. Card update history:
+   Append card changes as history instead of always replacing card details in place so change context is preserved over time.
 
 ## Local prerequisites
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ The system is designed around user-level multi-tenancy: cards, messages, agents,
 - [Backend architecture](./docs/backend-architecture.md)
   Detailed overview of the backend runtime flow, key design decisions, and extension points.
 
-## Main capabilities
+## Current MVPs
 
-- Ingest and queue messages for processing
-- Route messages through an orchestrator and agent loop
-- Create, update, search, and manage cards
-- Hybrid card search using full-text search plus embeddings
-- User-scoped agent tools for card workflows and utility tasks
-- Structured logging with MDC correlation fields
+- Message ingestion and database-backed queue processing
+- AI filtering and routing orchestration
+- Configurable agent execution with bounded tool loops
+- Card CRUD and status management
+- AI card tools for create, update, search, and status changes
+- Hybrid card search with full-text and embeddings
+- Message search and filtering
+- Agent and orchestrator configuration UI
+- Authenticated browser-based app flow
+- Structured logging, migrations, and test/coverage setup
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pateljheel_quintkard&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pateljheel_quintkard)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=pateljheel_quintkard&metric=coverage)](https://sonarcloud.io/summary/new_code?id=pateljheel_quintkard)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 
 Quintkard is a local-first workflow assistant for turning inbound messages into actionable cards. It combines a Spring Boot backend, a Next.js UI, database-backed message processing, AI-driven orchestration, agent tools, and hybrid card search.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,19 @@
 
 Quintkard is a local-first workflow assistant for turning inbound messages into actionable cards. It combines a Spring Boot backend, a Next.js UI, database-backed message processing, AI-driven orchestration, agent tools, and hybrid card search.
 
+The system is designed around user-level multi-tenancy: cards, messages, agents, orchestrator settings, and AI tool execution are intended to be scoped per user. At the moment, local usage and the main verified flow are still centered on the seeded `admin` user, so broader multi-user behavior should be treated as design intent rather than fully verified runtime coverage.
+
 ## Modules
 
 - `quintkard-app`
   Spring Boot backend with PostgreSQL, security, message queue processing, orchestration, card management, embeddings, and agent/tool execution.
 - `quintkard-ui`
   Next.js frontend for cards, messages, agents, orchestrator settings, and account management.
+
+## Architecture
+
+- [Backend architecture](./docs/backend-architecture.md)
+  Detailed overview of the backend runtime flow, key design decisions, and extension points.
 
 ## Main capabilities
 
@@ -29,12 +36,12 @@ Quintkard is a local-first workflow assistant for turning inbound messages into 
    Improve the cards UI so actionable items stand out more clearly and are easier to triage quickly.
 3. Message ingestion plugins:
    Add plugins for ingesting messages from Gmail and Slack.
-4. Stronger card filtering:
-   Expand the cards UI with richer filtering and narrowing options.
-5. Semantic linking:
+4. Semantic linking:
    Add semantic linking across cards and messages to surface related work and context automatically.
-6. Broader AI provider support:
+5. Broader AI provider support:
    Add support and test coverage for additional AI providers beyond the current Google GenAI setup.
+6. AI provider failure handling:
+   Add more robust handling for AI provider failures, including retries.
 
 ## Local prerequisites
 

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,0 +1,836 @@
+# Backend Architecture
+
+## Purpose
+
+This document describes the architecture of the `quintkard-app` backend:
+
+- the main runtime flow
+- important design decisions and why they exist
+- the primary extension points for future work
+
+The backend is a Spring Boot application that combines:
+
+- user-scoped CRUD APIs
+- a database-backed asynchronous message-processing pipeline
+- AI orchestration and agent execution
+- user-scoped AI tools
+- hybrid search over cards
+
+The goal of the design is to keep the write path simple for user-facing APIs while isolating AI-driven processing behind explicit orchestration and agent execution layers.
+
+## High-Level View
+
+At a high level, the backend has four major responsibilities:
+
+1. Serve authenticated user APIs for cards, messages, agents, orchestrator config, and account data.
+2. Persist incoming messages and process them asynchronously through a queue-backed pipeline.
+3. Use orchestration prompts to decide whether a message should be processed and which agents should run.
+4. Execute AI agents with a bounded tool loop against user-scoped tools.
+
+## Main Packages
+
+The main backend modules are:
+
+- `agent`
+  Agent configuration, persistence, and user-facing agent APIs.
+
+- `agentexecution`
+  Runtime execution of a selected agent, including loop control and tool-call execution.
+
+- `agenttool`
+  User-scoped and public AI tools exposed to agents.
+
+- `aimodel`
+  AI provider abstraction, model selection, memory integration, and Spring AI integration.
+
+- `card`
+  Card domain model, CRUD APIs, embeddings (chunking/indexing), and hybrid card search.
+
+- `config`
+  Security, queue, admin bootstrap, CSRF, and other application wiring.
+
+- `db`
+  Database-related helpers and migration entry points.
+
+- `embedding`
+  Embedding provider integration and embedding service.
+
+- `logging`
+  Structured application logging and MDC context propagation.
+
+- `message`
+  Message ingestion, message CRUD APIs, and message search.
+
+- `messagepipeline`
+  Database-backed queue polling and message processing entry point.
+
+- `orchestrator`
+  Persistent orchestrator configuration per user.
+
+- `orchestratorexecution`
+  Filtering, routing, and agent dispatch execution logic.
+
+- `redaction`
+  Redaction-related abstractions for future sensitive-data handling.
+
+- `user`
+  User persistence, security integration, and account APIs.
+
+## Request and Processing Flow
+
+### 1. User-facing API flow
+
+For normal CRUD operations, the flow is conventional:
+
+- controller accepts authenticated request
+- service enforces domain rules and user ownership
+- repository persists or fetches data
+
+Examples:
+
+- [`CardController.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardController.java)
+- [`MessageController.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageController.java)
+- [`AgentController.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agent/AgentController.java)
+- [`UserController.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/user/UserController.java)
+
+Important decision point:
+
+- User-facing APIs are user-scoped at the service/repository layer, not just by controller assumptions.
+- This keeps authorization tied to data access rules, not only request routing.
+
+### 2. Message ingestion flow
+
+Message ingestion is intentionally split from message processing.
+
+Flow:
+
+- [`MessageIngestionController.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageIngestionController.java)
+- [`MessageIngestionServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageIngestionServiceImpl.java)
+- persisted `Message` starts with `PENDING` status
+- background queue later claims and processes it
+
+Important decision point:
+
+- Ingestion is synchronous and lightweight.
+- Orchestration and agent execution are asynchronous.
+
+Why:
+
+- UI and upstream integrations should not block on AI execution.
+- Failed processing can be retried or marked failed without losing the original message.
+- Can be later decoupled into separate services or microservices if needed without affecting the ingestion API.
+
+### 3. Queue-backed message processing flow
+
+Asynchronous processing starts in:
+
+- [`DatabaseBackedMessageQueueService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java)
+
+Flow:
+
+1. scheduled poll checks whether `PENDING` messages exist
+2. worker claims a batch with `FOR UPDATE SKIP LOCKED`
+3. claimed messages are marked `PROCESSING`
+4. each message is processed by the configured `MessageProcessor`
+5. final status is updated to `SUCCESS` or `FAILED`
+
+Important decision point:
+
+- Queue claiming is global, not user-scoped.
+
+Why:
+
+- This component is queue infrastructure, not a user-facing query path.
+- Its job is to process any pending work in the system safely across worker threads.
+- Later the queue workers could be partitioned by tenant or user if needed.
+
+Related repository methods are therefore intentionally not user-scoped:
+
+- `claimMessageIdsByStatus(...)`
+- `existsByStatus(...)`
+- `findAllByIdIn(...)`
+
+User scope is reintroduced when a claimed message is processed because the message itself carries its owning user.
+
+### 4. Orchestration flow
+
+The default message processor is:
+
+- [`DefaultMessageProcessor.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DefaultMessageProcessor.java)
+
+It loads the user’s orchestrator config and delegates to:
+
+- [`OrchestratorExecutionServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImpl.java)
+
+Orchestration is a two-step AI decision:
+
+1. filtering
+   Decide whether the message deserves downstream processing.
+
+2. routing
+   Decide which active agent IDs should handle the message.
+
+Important decision point:
+
+- Filtering and routing are separate AI calls.
+
+Why:
+
+- It keeps the decision model small and easier to reason about.
+- It avoids pushing all selection logic into one prompt.
+- It makes logs and failure modes much clearer.
+
+If filtering rejects the message, routing is skipped.
+
+### 5. Agent dispatch flow
+
+If routing selects one or more agent IDs, orchestration delegates to:
+
+- [`AgentDispatchServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/AgentDispatchServiceImpl.java)
+
+Current behavior:
+
+- selected agents are executed sequentially
+- results are collected in a map keyed by agent ID
+
+Important decision point:
+
+- Dispatch is sequential, not parallel.
+
+Why:
+
+- each agent can access user-scoped tools and data, so to prevent race conditions and complexity around concurrent tool execution, agents are run one after another for now.
+
+Extension point:
+
+- This service is the right place to introduce parallel agent execution later if the design evolves in that direction.
+
+### 6. Agent execution flow
+
+Agent runtime starts in:
+
+- [`AgentExecutionServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentExecutionServiceImpl.java)
+
+This service:
+
+- normalizes the request
+- resolves default tool scope
+- applies runtime loop limits from configuration
+- delegates to the loop executor
+
+Actual iterative execution happens in:
+
+- [`AgentLoopExecutorImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImpl.java)
+
+Loop shape:
+
+1. build initial prompt from agent prompt + message context
+2. call the AI chat service
+3. inspect tool calls
+4. execute allowed tools
+5. feed tool results back as a tool message
+6. continue until:
+   - final response
+   - max iterations reached
+   - max tool calls reached
+
+Important decision points:
+
+- internal tool execution in provider SDK is disabled
+- tool execution is handled inside the application
+- tool failures are returned as tool results instead of crashing the whole loop
+
+Why:
+
+- user scope must be enforced by application code
+- logging and observability need to stay inside the app
+- provider-specific tool execution would reduce control over user/tenant boundaries
+- recoverable tool failures should still let the model continue reasoning
+
+## AI Model Layer
+
+The AI abstraction is intentionally narrow.
+
+Primary entry points:
+
+- [`AiChatService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiChatService.java)
+- [`SpringAiChatService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiChatService.java)
+
+Responsibilities of the AI model layer:
+
+- choose the provider/model from the configured catalog
+- build provider-specific options
+- integrate memory
+- translate between internal message/tool models and Spring AI types
+
+### Multi-provider design
+
+Provider registry:
+
+- [`DefaultAiChatModelRegistry.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatModelRegistry.java)
+
+Provider-specific options:
+
+- [`DefaultAiChatOptionsFactory.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/DefaultAiChatOptionsFactory.java)
+
+Provider beans:
+
+- [`AiModelConfiguration.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/AiModelConfiguration.java)
+
+Important decision point:
+
+- model name is resolved through an internal catalog, not by hardwiring provider logic across the application.
+
+Why:
+
+- allows OpenAI and Google models to coexist cleanly
+- keeps provider mapping centralized
+- avoids scattered `if model starts with ...` logic
+
+Extension point:
+
+- add a new provider by:
+  - extending the model catalog
+  - providing provider beans
+  - teaching the options factory how to build provider-specific options
+
+### Memory behavior
+
+Memory integration:
+
+- [`SpringAiMemoryService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiMemoryService.java)
+
+Current behavior:
+
+- chat memory is in-memory via Spring AI `ChatMemoryRepository`
+- orchestration and agent execution use a generated memory scope
+- memory is explicitly cleared when orchestration completes
+
+Important decision point:
+
+- memory is ephemeral per processing run
+
+Why:
+
+- current pipeline processes messages as bounded units of work
+- keeping memory after processing would create unbounded retention and hidden coupling
+- explicit cleanup avoids stale cross-run context
+
+Extension point:
+
+- replace in-memory repository with durable storage if long-lived conversational memory becomes a product requirement
+
+## Tool Layer
+
+AI tools are application-owned functions exposed to the model.
+
+Main interfaces:
+
+- [`AiTool.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/AiTool.java)
+- [`AiToolRegistry.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/AiToolRegistry.java)
+- [`AiToolScopeResolver.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/AiToolScopeResolver.java)
+
+Current scope resolution:
+
+- [`DefaultAiToolScopeResolver.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agenttool/DefaultAiToolScopeResolver.java)
+
+Current behavior:
+
+- only tools named in the allowed scope are available in a given agent run
+- user ID is passed into tool execution requests
+
+Important decision point:
+
+- tool access is capability-based, not globally open to every agent run
+
+Why:
+
+- narrows blast radius
+- makes agent behavior more predictable
+- supports per-agent specialization
+
+Current tool categories:
+
+- card tools
+  - create
+  - update
+  - change status
+  - get card
+  - hybrid search
+
+- utility/public tools
+  - current date
+  - current time
+  - timezone conversion
+
+Extension point:
+
+- add a new tool by implementing `AiTool`, registering it as a Spring bean, and allowing it through tool scope resolution
+
+## Card Domain and Search
+
+The `card` module owns structured work items generated from messages or direct user actions.
+
+Core classes:
+
+- [`CardServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java)
+- [`CardRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java)
+- [`CardSearchRepositoryImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java)
+
+### Filtered listing
+
+Normal filtered card listing uses:
+
+- `CardFilter`
+- `CardSpecifications`
+- JPA specification execution
+
+Important decision point:
+
+- structured filtering uses Specifications
+- hybrid search uses a custom repository
+
+Why:
+
+- Specifications are good for optional relational filters
+- hybrid ranking logic is too specialized for JPA abstraction
+
+### Hybrid search
+
+Hybrid search combines:
+
+- semantic ranking from vector embeddings
+- PostgreSQL full-text search ranking
+
+Important decision point:
+
+- hybrid search is implemented as explicit SQL, not ORM-generated query logic
+
+Why:
+
+- reciprocal-rank fusion and pgvector operations are database-native concerns
+- keeping this logic in SQL is clearer and more controllable than forcing it through JPA
+
+Security note:
+
+- dynamic query shape is assembled from trusted SQL fragments only
+- user values are bound as JDBC parameters
+- this avoids SQL injection while still supporting optional filters
+
+### Embeddings
+
+Embedding/indexing classes:
+
+- [`CardEmbeddingServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardEmbeddingServiceImpl.java)
+- [`EmbeddingConfiguration.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/EmbeddingConfiguration.java)
+- [`SpringAiEmbeddingService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/embedding/SpringAiEmbeddingService.java)
+
+Cards are reindexed on create/update, which keeps semantic retrieval aligned with current content.
+
+Extension points:
+
+- different chunking strategies
+- different embedding models
+- different vector store strategy if PostgreSQL/pgvector stops fitting
+
+## Message Domain and Search
+
+The `message` module owns:
+
+- raw ingested messages
+- message metadata
+- filtered listing
+- message search
+
+As with cards:
+
+- structured listing uses `MessageFilter` + `MessageSpecifications`
+- full-text search uses [`MessageSearchRepositoryImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImpl.java)
+
+Important decision point:
+
+- message storage is the source of truth for ingestion
+- downstream orchestration output is recorded into message details rather than replacing the original payload
+
+Why:
+
+- preserves auditability
+- allows reprocessing with new prompts or models later
+
+## Persistence and Schema Management
+
+Persistence uses:
+
+- Spring Data JPA for core entity CRUD
+- custom repositories for advanced SQL paths
+- Flyway migrations for schema and indexing
+
+Important decision point:
+
+- schema evolution is owned by Flyway migrations, not by runtime auto-DDL
+
+Why:
+
+- repeatable, explicit schema changes
+- safer production rollout
+- easier CI verification
+
+Extension points:
+
+- new tables and indexes via new Flyway migrations
+- additional projections or custom repositories for database-specific workloads
+
+## Security
+
+Security wiring lives in:
+
+- [`SecurityConfig.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java)
+- [`QuintkardUserDetailsService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/user/QuintkardUserDetailsService.java)
+
+Current model:
+
+- HTTP Basic authentication
+- browser CSRF protection enabled
+- explicit CSRF bootstrap endpoint for the SPA
+- CORS configured through application properties
+
+Important decision point:
+
+- CSRF is enabled because the UI is a browser client performing mutating requests
+
+Why:
+
+- browser-based authenticated APIs should not rely only on authentication
+- mutating requests need anti-forgery protection
+
+Extension points:
+
+- move to stronger auth/session/token models later
+- tighten authorization beyond authenticated-user-only as roles and tenancy needs evolve
+
+## Logging and Observability
+
+Logging infrastructure lives in:
+
+- `logging` package
+- MDC/LogContext propagation
+
+Important decision point:
+
+- log context carries `userId`, `messageId`, `runId`, `agentId`, and `toolName`
+
+Why:
+
+- AI workflows are multi-step and difficult to debug without correlated logs
+
+This is especially important across:
+
+- queue processing
+- orchestration
+- agent execution
+- tool calls
+
+## Important Architectural Decisions
+
+These are the most important design choices in the current backend:
+
+### 1. Asynchronous message processing
+
+- ingestion is decoupled from orchestration
+- improves responsiveness and failure isolation
+- later can be decoupled into separate service and scaled independently if needed
+
+### 2. Separate orchestration from agent execution
+
+- orchestrator decides if and where to route
+- agents perform domain actions
+- keeps decision-making distinct from execution
+
+### 3. Application-owned tool execution
+
+- tools run inside backend code, not inside provider-managed execution
+- preserves user scope, logging, and control
+
+### 4. Specifications for structured filters, SQL for hybrid search
+
+- clean split between relational filtering and ranking-heavy retrieval
+
+### 5. Ephemeral memory per processing run
+
+- reduces hidden state and simplifies reasoning
+
+### 6. Multi-provider AI model abstraction
+
+- provider choice is centralized and configurable
+- avoids locking business logic to one provider
+
+## Primary Extension Points
+
+The cleanest extension points in the current design are:
+
+### Add a new AI provider
+
+Touch:
+
+- model catalog properties
+- model registry
+- options factory
+- provider bean configuration
+
+### Add a new agent tool
+
+Touch:
+
+- `agenttool` package
+- tool registry
+- agent configs/tool scopes
+
+### Add a new orchestration step
+
+Likely touch:
+
+- `OrchestratorExecutionService`
+- `DefaultMessageProcessor`
+- orchestration result schema/details payload
+
+### Add persistent memory
+
+Touch:
+
+- `AiMemoryService`
+- Spring AI `ChatMemoryRepository`
+- lifecycle policy around cleanup
+
+### Add new card/message filters
+
+Touch:
+
+- filter record
+- specifications
+- controller request parameters
+- UI query params if needed
+
+### Add richer graph/linking behavior between cards and messages
+
+Likely touch:
+
+- card domain model
+- new relational/link tables
+- orchestration or tool logic that creates and updates links
+- UI query/read models
+
+### Parallel agent execution
+
+Touch:
+
+- `AgentDispatchServiceImpl`
+- logging context propagation
+- result aggregation semantics
+
+## Known Tradeoffs
+
+The current architecture deliberately accepts a few tradeoffs:
+
+- in-memory AI memory is simple but not durable
+- sequential agent dispatch is simpler but slower than parallel fan-out
+- prompt-driven orchestration is flexible but can be nondeterministic
+- queue processing is global rather than partitioned by tenant/user
+- hybrid search is PostgreSQL-specific and intentionally database-aware
+
+These are acceptable for the current stage because they keep the system understandable while preserving good extension paths.
+
+## Scalability Concerns Not Yet Verified
+
+The current backend design is functionally structured for growth, but several scalability characteristics have not been verified with load or production-like concurrency testing yet.
+
+These are the main areas to watch:
+
+### 1. Global queue polling and batch claiming
+
+Current behavior:
+
+- one database-backed queue polls for any `PENDING` messages
+- claiming uses `FOR UPDATE SKIP LOCKED`
+- work is drained in batches by the queue worker
+
+Potential concerns:
+
+- queue hot spots if message volume grows significantly
+- database contention on the `messages` table under heavy concurrent claiming
+- uneven fairness across users because claiming is global, not partitioned
+- high-volume users may dominate queue throughput
+
+What is not yet verified:
+
+- behavior with many workers across multiple application instances (cannot be tested until the queue is decoupled from the main app)
+- throughput under sustained ingestion spikes
+- recovery characteristics under repeated failure/retry storms
+
+### 2. Sequential agent dispatch
+
+Current behavior:
+
+- routed agents are executed sequentially for a message
+
+Potential concerns:
+
+- a single long-running agent delays all later agents for the same message
+- end-to-end latency increases linearly with number of routed agents
+- queue throughput may degrade when many messages route to multiple agents
+
+What is not yet verified:
+
+- whether sequential dispatch remains acceptable with higher routing fan-out
+- whether parallel execution would materially improve throughput without harming determinism
+
+### 3. Agent tool loop cost
+
+Current behavior:
+
+- each agent run may iterate multiple times
+- each iteration may trigger multiple tool calls
+- each tool call may trigger database work, embeddings, or provider API calls
+
+Potential concerns:
+
+- multiplicative cost growth under long prompts and multi-step reasoning
+- expensive tool-heavy runs reducing total queue capacity
+- higher variance in processing time across messages
+
+What is not yet verified:
+
+- practical upper bounds for message throughput under realistic AI latency
+- safe production values for iteration and tool-call limits at scale
+
+### 4. In-memory chat memory repository
+
+Current behavior:
+
+- chat memory is stored in an in-memory Spring AI repository
+- orchestration clears memory after a processing run
+
+Potential concerns:
+
+- memory pressure if cleanup fails or usage patterns change
+- no sharing across application instances
+- no durability or replay of conversational state
+
+What is not yet verified:
+
+- memory behavior under long-lived runs or large concurrent processing counts
+- operational impact if future product features require longer retention
+
+### 5. PostgreSQL-backed hybrid search
+
+Current behavior:
+
+- card hybrid search uses PostgreSQL full-text search plus pgvector ranking
+- message search uses PostgreSQL full-text search
+
+Potential concerns:
+
+- ranking queries may become expensive as row counts and embedding counts grow
+- pgvector distance scans can become a bottleneck if indexing strategy is insufficient
+- search latency may vary substantially by query shape and corpus size
+
+What is not yet verified:
+
+- query latency at larger card/message volumes
+- behavior with significantly larger embedding tables
+- when dedicated search infrastructure would become justified
+
+### 6. Embedding reindex cost on card mutations
+
+Current behavior:
+
+- card create/update triggers embedding reindexing
+
+Potential concerns:
+
+- card write throughput may degrade if embedding generation becomes slow
+- backpressure may build if many cards are updated in bursts
+- synchronous reindex coupling can make write latency sensitive to embedding provider performance
+
+What is not yet verified:
+
+- write-path impact under high card mutation volume
+- whether embedding work should eventually move to its own async pipeline
+
+### 7. Multi-user isolation under load
+
+Current behavior:
+
+- the design is user-scoped at the domain and tool-execution level
+- the main verified runtime path still centers on the seeded `admin` user
+
+Potential concerns:
+
+- fairness and isolation characteristics have not been exercised with many active users
+- queue, search, and orchestration behavior may surface different bottlenecks in real multi-user traffic
+
+What is not yet verified:
+
+- concurrency behavior across many active users
+- whether user-level quotas, prioritization, or partitioning are needed
+
+### 8. AI provider dependency and latency concentration
+
+Current behavior:
+
+- orchestration and agent execution depend on external AI providers
+
+Potential concerns:
+
+- provider latency directly impacts queue drain rate
+- provider outages or rate limits can reduce or stall processing throughput
+- long-tail AI response times can amplify worker occupancy
+
+What is not yet verified:
+
+- throughput under real provider latency variance
+- resilience under provider throttling or intermittent failures
+- whether additional circuit breaking, work shedding, or retry shaping is needed
+
+### 9. Logging volume
+
+Current behavior:
+
+- the application logs orchestration, routing, agent execution, and tool call activity in detail
+
+Potential concerns:
+
+- log volume may become large under heavy queue throughput
+- tool argument/result logging may increase storage cost and I/O pressure
+- verbose logs can become operationally expensive before application compute becomes the main bottleneck
+
+What is not yet verified:
+
+- production log volume at sustained message-processing rates
+- whether some log categories should become sampled or level-gated
+
+### Recommended next validation steps
+
+The highest-value scalability validation work would be:
+
+1. queue throughput and worker-concurrency testing
+2. hybrid search latency testing at larger dataset sizes
+3. multi-user concurrency testing beyond the seeded admin flow
+4. AI-provider latency and failure injection testing
+5. measurement of log volume and storage cost under sustained load
+
+## Recommended Reading Order in Code
+
+For someone new to the backend, the best reading order is:
+
+1. [`DatabaseBackedMessageQueueService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java)
+2. [`DefaultMessageProcessor.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DefaultMessageProcessor.java)
+3. [`OrchestratorExecutionServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/OrchestratorExecutionServiceImpl.java)
+4. [`AgentDispatchServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestratorexecution/AgentDispatchServiceImpl.java)
+5. [`AgentExecutionServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentExecutionServiceImpl.java)
+6. [`AgentLoopExecutorImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agentexecution/AgentLoopExecutorImpl.java)
+7. [`SpringAiChatService.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/aimodel/SpringAiChatService.java)
+8. [`CardServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java)
+9. [`CardSearchRepositoryImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java)
+10. [`MessageServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageServiceImpl.java)
+
+That path mirrors the actual runtime behavior of the most important backend flow.

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/CsrfController.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/CsrfController.java
@@ -1,0 +1,20 @@
+package io.quintkard.quintkardapp.config;
+
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/csrf")
+public class CsrfController {
+
+    @GetMapping
+    public CsrfTokenResponse csrfToken(CsrfToken csrfToken) {
+        return new CsrfTokenResponse(
+                csrfToken.getHeaderName(),
+                csrfToken.getParameterName(),
+                csrfToken.getToken()
+        );
+    }
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/CsrfTokenResponse.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/CsrfTokenResponse.java
@@ -1,0 +1,8 @@
+package io.quintkard.quintkardapp.config;
+
+public record CsrfTokenResponse(
+        String headerName,
+        String parameterName,
+        String token
+) {
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -22,7 +22,7 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.csrfTokenRepository(new CookieCsrfTokenRepository()))
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
@@ -39,9 +39,9 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(securityCorsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-XSRF-TOKEN"));
         configuration.setExposedHeaders(List.of("WWW-Authenticate"));
-        configuration.setAllowCredentials(false);
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
@@ -1,0 +1,147 @@
+package io.quintkard.quintkardapp.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.quintkard.quintkardapp.card.Card;
+import io.quintkard.quintkardapp.card.CardController;
+import io.quintkard.quintkardapp.card.CardPriority;
+import io.quintkard.quintkardapp.card.CardRequest;
+import io.quintkard.quintkardapp.card.CardService;
+import io.quintkard.quintkardapp.card.CardStatus;
+import io.quintkard.quintkardapp.card.CardType;
+import io.quintkard.quintkardapp.user.User;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = {CardController.class, CsrfController.class})
+@Import(SecurityConfig.class)
+class CsrfSecurityTest {
+
+    private static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
+    private static final String CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+    private static final String CSRF_PARAMETER_NAME = "_csrf";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CardService cardService;
+
+    @MockitoBean
+    private SecurityCorsProperties securityCorsProperties;
+
+    @MockitoBean
+    @SuppressWarnings("unused")
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void csrfEndpointReturnsTokenAndCookie() throws Exception {
+        when(securityCorsProperties.getAllowedOrigins()).thenReturn(java.util.List.of("http://localhost:3000"));
+
+        mockMvc.perform(get("/api/csrf").with(user("admin")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.headerName").value(CSRF_HEADER_NAME))
+                .andExpect(jsonPath("$.parameterName").value(CSRF_PARAMETER_NAME))
+                .andExpect(jsonPath("$.token").isNotEmpty())
+                .andExpect(cookie().exists(CSRF_COOKIE_NAME));
+    }
+
+    @Test
+    void postWithoutCsrfTokenIsRejected() throws Exception {
+        when(securityCorsProperties.getAllowedOrigins()).thenReturn(java.util.List.of("http://localhost:3000"));
+
+        mockMvc.perform(post("/api/cards")
+                        .with(user("admin"))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(cardRequestJson()))
+                .andExpect(status().isForbidden());
+
+        verify(cardService, never()).createCard(eq("admin"), any(CardRequest.class));
+    }
+
+    @Test
+    void postWithCsrfTokenFromEndpointIsAccepted() throws Exception {
+        when(securityCorsProperties.getAllowedOrigins()).thenReturn(java.util.List.of("http://localhost:3000"));
+        when(cardService.createCard(eq("admin"), any(CardRequest.class))).thenReturn(card());
+
+        MvcResult csrfResult = mockMvc.perform(get("/api/csrf").with(user("admin")))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String csrfPayload = csrfResult.getResponse().getContentAsString();
+        JsonNode payload = objectMapper.readTree(csrfPayload);
+        String token = payload.get("token").asText();
+        jakarta.servlet.http.Cookie csrfCookie =
+                csrfResult.getResponse().getCookie(CSRF_COOKIE_NAME);
+
+        mockMvc.perform(post("/api/cards")
+                        .with(user("admin"))
+                        .cookie(csrfCookie)
+                        .header(CSRF_HEADER_NAME, token)
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(cardRequestJson()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value("admin"))
+                .andExpect(jsonPath("$.title").value("Follow up"))
+                .andExpect(jsonPath("$.cardType").value("FOLLOW_UP"));
+
+        verify(cardService).createCard(eq("admin"), any(CardRequest.class));
+    }
+
+    private static String cardRequestJson() {
+        return """
+                {
+                  "title": "Follow up",
+                  "summary": "Invoice",
+                  "content": "Review discrepancy",
+                  "cardType": "FOLLOW_UP",
+                  "status": "OPEN",
+                  "priority": "MEDIUM",
+                  "dueDate": "2026-05-29"
+                }
+                """;
+    }
+
+    private static Card card() {
+        Card card = new Card(
+                new User("admin", "Admin", "admin@example.com", "hash", false),
+                "Follow up",
+                "Invoice",
+                "Review discrepancy",
+                CardType.FOLLOW_UP,
+                CardStatus.OPEN,
+                CardPriority.MEDIUM,
+                LocalDate.of(2026, 5, 29),
+                null
+        );
+        ReflectionTestUtils.setField(card, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(card, "createdAt", Instant.parse("2026-04-05T00:00:00Z"));
+        ReflectionTestUtils.setField(card, "updatedAt", Instant.parse("2026-04-05T01:00:00Z"));
+        return card;
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
@@ -95,7 +95,7 @@ class CsrfSecurityTest {
 
         String csrfPayload = csrfResult.getResponse().getContentAsString();
         JsonNode payload = objectMapper.readTree(csrfPayload);
-        String token = payload.get("token").asText();
+        String token = payload.get("token").textValue();
         jakarta.servlet.http.Cookie csrfCookie =
                 csrfResult.getResponse().getCookie(CSRF_COOKIE_NAME);
 

--- a/quintkard-ui/lib/api.ts
+++ b/quintkard-ui/lib/api.ts
@@ -1,16 +1,62 @@
-import { apiBaseUrl } from "./auth";
+import { apiBaseUrl, getStoredAuth, getStoredCsrfToken, setStoredCsrfToken } from "./auth";
 
 type ApiRequestInit = RequestInit & {
   path: string;
 };
 
+const CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+type CsrfTokenResponse = {
+  headerName: string;
+  parameterName: string;
+  token: string;
+};
+
+async function ensureCsrfToken(headers: Headers) {
+  const existingToken = getStoredCsrfToken();
+  if (existingToken) {
+    headers.set(CSRF_HEADER_NAME, existingToken);
+    return;
+  }
+
+  const authHeader = headers.get("Authorization") ?? getStoredAuth();
+  const tokenHeaders = new Headers();
+  if (authHeader) {
+    tokenHeaders.set("Authorization", authHeader);
+  }
+
+  const response = await fetch(`${apiBaseUrl}/api/csrf`, {
+    method: "GET",
+    headers: tokenHeaders,
+    credentials: "include"
+  });
+
+  if (!response.ok) {
+    throw new Error("Unable to initialize CSRF protection.");
+  }
+
+  const payload = (await response.json()) as CsrfTokenResponse;
+  setStoredCsrfToken(payload.token);
+  headers.set(payload.headerName || CSRF_HEADER_NAME, payload.token);
+}
+
 export async function apiFetch({ path, ...init }: ApiRequestInit) {
   const url = `${apiBaseUrl}${path}`;
   const method = init.method ?? "GET";
   const startedAt = performance.now();
+  const headers = new Headers(init.headers);
 
   try {
-    const response = await fetch(url, init);
+    if (MUTATING_METHODS.has(method.toUpperCase())) {
+      await ensureCsrfToken(headers);
+    }
+
+    const response = await fetch(url, {
+      ...init,
+      headers,
+      credentials: "include"
+    });
     const latencyMs = performance.now() - startedAt;
 
     console.info(

--- a/quintkard-ui/lib/auth.ts
+++ b/quintkard-ui/lib/auth.ts
@@ -1,5 +1,6 @@
 export const apiBaseUrl = "http://localhost:8080";
 export const authStorageKey = "quintkard-basic-auth";
+export const csrfStorageKey = "quintkard-csrf-token";
 
 export function toBasicAuth(username: string, password: string) {
   if (typeof window === "undefined") {
@@ -31,4 +32,21 @@ export function clearStoredAuth() {
   }
 
   window.sessionStorage.removeItem(authStorageKey);
+  window.sessionStorage.removeItem(csrfStorageKey);
+}
+
+export function getStoredCsrfToken() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return window.sessionStorage.getItem(csrfStorageKey) ?? "";
+}
+
+export function setStoredCsrfToken(token: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.sessionStorage.setItem(csrfStorageKey, token);
 }

--- a/quintkard-ui/package-lock.json
+++ b/quintkard-ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "quintkard-ui",
       "version": "0.1.0",
       "dependencies": {
-        "next": "latest",
+        "next": "^16.2.3",
         "react": "latest",
         "react-dom": "latest"
       },
@@ -544,15 +544,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
-      "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
-      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -639,9 +639,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -802,12 +802,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
-      "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.2",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -821,14 +821,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.2",
-        "@next/swc-darwin-x64": "16.2.2",
-        "@next/swc-linux-arm64-gnu": "16.2.2",
-        "@next/swc-linux-arm64-musl": "16.2.2",
-        "@next/swc-linux-x64-gnu": "16.2.2",
-        "@next/swc-linux-x64-musl": "16.2.2",
-        "@next/swc-win32-arm64-msvc": "16.2.2",
-        "@next/swc-win32-x64-msvc": "16.2.2",
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/quintkard-ui/package.json
+++ b/quintkard-ui/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
+    "next": "^16.2.3",
     "react": "latest",
     "react-dom": "latest"
   },


### PR DESCRIPTION
## Summary
- enable CSRF protection for browser-based API clients
- add backend tests proving CSRF rejection and acceptance behavior
- upgrade Next.js to 16.2.3 to address the Server Components DoS vulnerability
- add backend architecture documentation and README links/notes

## Verification
- ./gradlew compileJava
- ./gradlew test --tests 'io.quintkard.quintkardapp.config.CsrfSecurityTest'
- ./gradlew test jacocoTestReport
- npm run build

## Notes
- CSRF is now enforced for mutating browser requests via a token bootstrap endpoint and shared frontend request handling
- Next.js is pinned to a patched version instead of floating on latest
- README now clarifies the intended user-level multi-tenant design while noting that the main verified runtime path is still centered on the seeded admin user
- Added a backend architecture document covering runtime flow, important design decisions, extension points, and currently unverified scalability concerns