### PR TITLE
Harden message repository tenant boundaries

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -152,6 +152,16 @@ Related repository methods are therefore intentionally not user-scoped:
 
 User scope is reintroduced when a claimed message is processed because the message itself carries its owning user.
 
+Repository boundary note:
+
+- queue-facing data access is intentionally separated into [`InternalMessageQueueRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/InternalMessageQueueRepository.java)
+- user-facing message CRUD/search stays on [`MessageRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java)
+
+Why:
+
+- it prevents queue infrastructure methods from leaking into normal user-facing services
+- it makes trusted cross-tenant access explicit in code review and architecture tests
+
 ### 4. Orchestration flow
 
 The default message processor is:
@@ -376,6 +386,7 @@ Core classes:
 - [`CardServiceImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardServiceImpl.java)
 - [`CardRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java)
 - [`CardSearchRepositoryImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardSearchRepositoryImpl.java)
+- [`InternalCardMaintenanceRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/InternalCardMaintenanceRepository.java)
 
 ### Filtered listing
 
@@ -389,11 +400,13 @@ Important decision point:
 
 - structured filtering uses Specifications
 - hybrid search uses a custom repository
+- user-facing card access is separated from internal card maintenance access
 
 Why:
 
 - Specifications are good for optional relational filters
 - hybrid ranking logic is too specialized for JPA abstraction
+- embedding maintenance needs one trusted unscoped lookup path, but that path should not be available to normal card services or controllers
 
 ### Hybrid search
 
@@ -427,6 +440,16 @@ Embedding/indexing classes:
 
 Cards are reindexed on create/update, which keeps semantic retrieval aligned with current content.
 
+Repository boundary note:
+
+- [`CardRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java) is the user-facing repository surface for scoped card operations
+- [`InternalCardMaintenanceRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/InternalCardMaintenanceRepository.java) exists only for trusted maintenance access used by embedding reindexing
+
+Why:
+
+- the card service should only see user-scoped methods
+- maintenance code still needs a narrowly scoped internal path to reload cards by ID during reindex operations
+
 Extension points:
 
 - different chunking strategies
@@ -446,24 +469,28 @@ As with cards:
 
 - structured listing uses `MessageFilter` + `MessageSpecifications`
 - full-text search uses [`MessageSearchRepositoryImpl.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageSearchRepositoryImpl.java)
+- queue infrastructure uses a separate internal repository surface
 
 Important decision point:
 
 - message storage is the source of truth for ingestion
 - downstream orchestration output is recorded into message details rather than replacing the original payload
+- repository boundaries distinguish user-scoped message access from trusted queue access
 
 Why:
 
 - preserves auditability
 - allows reprocessing with new prompts or models later
+- avoids mixing global queue methods into normal message service code
 
 ## Persistence and Schema Management
 
 Persistence uses:
 
-- Spring Data JPA for core entity CRUD
+- Spring Data JPA with narrowed repository interfaces for user-owned entities
 - custom repositories for advanced SQL paths
 - Flyway migrations for schema and indexing
+- explicit internal repositories where trusted cross-tenant or maintenance access is required
 
 Important decision point:
 
@@ -474,6 +501,50 @@ Why:
 - repeatable, explicit schema changes
 - safer production rollout
 - easier CI verification
+
+### Repository Surface Hardening
+
+User-owned aggregates now use narrowed repository interfaces instead of broad `JpaRepository` exposure.
+
+Current pattern:
+
+- user-facing repositories expose only the operations the application actually uses
+- trusted cross-tenant or maintenance access is moved into explicitly named internal repositories
+
+Examples:
+
+- [`MessageRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java)
+- [`InternalMessageQueueRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/InternalMessageQueueRepository.java)
+- [`CardRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java)
+- [`InternalCardMaintenanceRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/card/InternalCardMaintenanceRepository.java)
+- [`AgentConfigRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/agent/AgentConfigRepository.java)
+- [`OrchestratorConfigRepository.java`](../quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestrator/OrchestratorConfigRepository.java)
+
+Important decision point:
+
+- tenant-owned repository APIs are treated as part of the security boundary
+
+Why:
+
+- broad repository defaults like `findById`, `findAll`, and `deleteById` are tenant-blind
+- removing those defaults makes it harder for future code to bypass user scoping accidentally
+- explicit internal repository names make trusted exceptions visible
+
+### Architecture Guardrails
+
+Architecture rules are enforced with ArchUnit in:
+
+- [`TenantIsolationArchitectureTest.java`](../quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java)
+
+Current guardrails enforce:
+
+- tenant-owned repositories in the main user-owned packages do not extend `JpaRepository`
+- user-facing controllers and primary user-facing services do not depend on repositories following the `Internal*Repository` pattern
+
+Why:
+
+- this turns repository-boundary decisions into executable rules rather than relying only on code review
+- it reduces the chance that future refactors accidentally reintroduce unscoped access paths
 
 Extension points:
 

--- a/quintkard-app/build.gradle
+++ b/quintkard-app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-flyway-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
     testImplementation 'org.testcontainers:junit-jupiter:1.21.0'
     testImplementation 'org.testcontainers:postgresql:1.21.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/agent/AgentConfigRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/agent/AgentConfigRepository.java
@@ -1,12 +1,13 @@
 package io.quintkard.quintkardapp.agent;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.repository.Repository;
 
-public interface AgentConfigRepository extends JpaRepository<AgentConfig, UUID> {
+public interface AgentConfigRepository extends Repository<AgentConfig, UUID> {
+
+    AgentConfig save(AgentConfig agentConfig);
 
     long countByUser_UserId(String userId);
 
@@ -15,4 +16,6 @@ public interface AgentConfigRepository extends JpaRepository<AgentConfig, UUID> 
     Optional<AgentConfig> findByUser_UserIdAndName(String userId, String name);
 
     List<AgentConfig> findAllByUser_UserId(String userId);
+
+    void delete(AgentConfig agentConfig);
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardEmbeddingRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardEmbeddingRepository.java
@@ -2,9 +2,11 @@ package io.quintkard.quintkardapp.card;
 
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface CardEmbeddingRepository extends JpaRepository<CardEmbedding, UUID> {
+public interface CardEmbeddingRepository extends Repository<CardEmbedding, UUID> {
+
+    List<CardEmbedding> saveAll(Iterable<CardEmbedding> embeddings);
 
     void deleteByCard_Id(UUID cardId);
 

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardEmbeddingServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardEmbeddingServiceImpl.java
@@ -13,20 +13,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CardEmbeddingServiceImpl implements CardEmbeddingService {
 
-    private final CardRepository cardRepository;
+    private final InternalCardMaintenanceRepository cardMaintenanceRepository;
     private final CardEmbeddingRepository cardEmbeddingRepository;
     private final EmbeddingService embeddingService;
     private final CardChunkingStrategyRegistry chunkingStrategyRegistry;
     private final EmbeddingProperties embeddingProperties;
 
     public CardEmbeddingServiceImpl(
-            CardRepository cardRepository,
+            InternalCardMaintenanceRepository cardMaintenanceRepository,
             CardEmbeddingRepository cardEmbeddingRepository,
             EmbeddingService embeddingService,
             CardChunkingStrategyRegistry chunkingStrategyRegistry,
             EmbeddingProperties embeddingProperties
     ) {
-        this.cardRepository = cardRepository;
+        this.cardMaintenanceRepository = cardMaintenanceRepository;
         this.cardEmbeddingRepository = cardEmbeddingRepository;
         this.embeddingService = embeddingService;
         this.chunkingStrategyRegistry = chunkingStrategyRegistry;
@@ -36,7 +36,7 @@ public class CardEmbeddingServiceImpl implements CardEmbeddingService {
     @Override
     @Transactional
     public List<CardEmbedding> reindexCard(UUID cardId) {
-        Card card = cardRepository.findById(cardId)
+        Card card = cardMaintenanceRepository.findById(cardId)
                 .orElseThrow(() -> new NoSuchElementException("Card not found: " + cardId));
 
         CardChunkingStrategy chunkingStrategy = chunkingStrategyRegistry.get(embeddingProperties.chunkingStrategy());

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/CardRepository.java
@@ -2,10 +2,14 @@ package io.quintkard.quintkardapp.card;
 
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.Repository;
 
-public interface CardRepository extends JpaRepository<Card, UUID>, JpaSpecificationExecutor<Card>, CardSearchRepository {
+public interface CardRepository extends Repository<Card, UUID>, JpaSpecificationExecutor<Card>, CardSearchRepository {
+
+    Card save(Card card);
 
     Optional<Card> findByIdAndUser_UserId(UUID id, String userId);
+
+    void delete(Card card);
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/InternalCardMaintenanceRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/card/InternalCardMaintenanceRepository.java
@@ -1,0 +1,10 @@
+package io.quintkard.quintkardapp.card;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+public interface InternalCardMaintenanceRepository extends Repository<Card, UUID> {
+
+    Optional<Card> findById(UUID id);
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageIngestionServiceImpl.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageIngestionServiceImpl.java
@@ -43,7 +43,11 @@ public class MessageIngestionServiceImpl implements MessageIngestionService {
             messages.add(buildMessage(userId, envelope));
         }
 
-        return messageRepository.saveAll(messages);
+        List<Message> savedMessages = new ArrayList<>();
+        for (Message message : messageRepository.saveAll(messages)) {
+            savedMessages.add(message);
+        }
+        return savedMessages;
     }
 
     private Message buildMessage(String userId, MessageEnvelope envelope) {

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/message/MessageRepository.java
@@ -1,31 +1,22 @@
 package io.quintkard.quintkardapp.message;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.Repository;
 
-public interface MessageRepository extends JpaRepository<Message, UUID>, JpaSpecificationExecutor<Message>, MessageSearchRepository {
+public interface MessageRepository extends Repository<Message, UUID>, JpaSpecificationExecutor<Message>, MessageSearchRepository {
 
-    @Query(
-        value = """
-            select id
-            from messages
-            where status = :status
-            order by ingested_at asc
-            limit :batchSize
-            for update skip locked
-            """,
-        nativeQuery = true
-    )
-    List<UUID> claimMessageIdsByStatus(@Param("status") String status, @Param("batchSize") int batchSize);
+    Message save(Message message);
 
-    boolean existsByStatus(MessageStatus status);
+    Iterable<Message> saveAll(Iterable<Message> messages);
 
-    List<Message> findAllByIdIn(List<UUID> ids);
+    Page<Message> findAll(Specification<Message> specification, Pageable pageable);
 
     Optional<Message> findByIdAndUserUserId(UUID id, String userId);
+
+    void delete(Message message);
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueService.java
@@ -3,7 +3,6 @@ package io.quintkard.quintkardapp.messagepipeline;
 import io.quintkard.quintkardapp.config.MessageQueueProperties;
 import io.quintkard.quintkardapp.logging.LogContext;
 import io.quintkard.quintkardapp.message.Message;
-import io.quintkard.quintkardapp.message.MessageRepository;
 import io.quintkard.quintkardapp.message.MessageStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +29,13 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
 
     private final int batchSize;
     private final MessageProcessor messageProcessor;
-    private final MessageRepository messageRepository;
+    private final InternalMessageQueueRepository messageQueueRepository;
     private final ThreadPoolTaskExecutor taskExecutor;
     private final TransactionTemplate transactionTemplate;
     private final AtomicBoolean workerRunning = new AtomicBoolean(false);
 
     public DatabaseBackedMessageQueueService(
-        MessageRepository messageRepository,
+        InternalMessageQueueRepository messageQueueRepository,
         MessageProcessor messageProcessor,
         PlatformTransactionManager transactionManager,
         @Qualifier("messageQueueTaskExecutor") ThreadPoolTaskExecutor taskExecutor,
@@ -44,7 +43,7 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
     ) {
         this.batchSize = messageQueueProperties.getBatchSize();
         this.messageProcessor = messageProcessor;
-        this.messageRepository = messageRepository;
+        this.messageQueueRepository = messageQueueRepository;
         this.taskExecutor = taskExecutor;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
@@ -82,18 +81,18 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
 
     private boolean hasPendingMessages() {
         return transactionTemplate.execute(
-            status -> messageRepository.existsByStatus(MessageStatus.PENDING)
+            status -> messageQueueRepository.existsByStatus(MessageStatus.PENDING)
         );
     }
 
     private List<Message> claimPendingMessages() {
         return transactionTemplate.execute(status -> {
-            List<UUID> ids = messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), batchSize);
+            List<UUID> ids = messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), batchSize);
             if (ids == null || ids.isEmpty()) {
                 return List.of();
             }
 
-            List<Message> fetchedMessages = messageRepository.findAllByIdIn(ids);
+            List<Message> fetchedMessages = messageQueueRepository.findAllByIdIn(ids);
             Map<UUID, Message> messagesById = new HashMap<>();
             for (Message message : fetchedMessages) {
                 messagesById.put(message.getId(), message);
@@ -109,7 +108,7 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
                 claimedMessages.add(message);
             }
 
-            return messageRepository.saveAll(claimedMessages);
+            return toList(messageQueueRepository.saveAll(claimedMessages));
         });
     }
 
@@ -121,7 +120,7 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
             logger.info("Message processing started");
             try {
                 transactionTemplate.executeWithoutResult(status -> {
-                    Message managedMessage = messageRepository.findById(message.getId())
+                    Message managedMessage = messageQueueRepository.findById(message.getId())
                         .orElseThrow(() -> new NoSuchElementException("Message not found: " + message.getId()));
 
                     try (AutoCloseable userContext = LogContext.with("userId", managedMessage.getUser().getUserId())) {
@@ -143,7 +142,7 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
 
     private void updateMessageStatus(UUID messageId, MessageStatus messageStatus) {
         transactionTemplate.executeWithoutResult(status -> {
-            Message message = messageRepository.findById(messageId)
+            Message message = messageQueueRepository.findById(messageId)
                 .orElseThrow(() -> new NoSuchElementException("Message not found: " + messageId));
 
             if (messageStatus == MessageStatus.SUCCESS) {
@@ -160,5 +159,13 @@ public class DatabaseBackedMessageQueueService implements MessageQueueService {
                 message.markProcessing();
             }
         });
+    }
+
+    private List<Message> toList(Iterable<Message> messages) {
+        List<Message> values = new ArrayList<>();
+        for (Message message : messages) {
+            values.add(message);
+        }
+        return values;
     }
 }

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/InternalMessageQueueRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/messagepipeline/InternalMessageQueueRepository.java
@@ -1,0 +1,34 @@
+package io.quintkard.quintkardapp.messagepipeline;
+
+import io.quintkard.quintkardapp.message.Message;
+import io.quintkard.quintkardapp.message.MessageStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface InternalMessageQueueRepository extends Repository<Message, UUID> {
+
+    @Query(
+            value = """
+                select id
+                from messages
+                where status = :status
+                order by ingested_at asc
+                limit :batchSize
+                for update skip locked
+                """,
+            nativeQuery = true
+    )
+    List<UUID> claimMessageIdsByStatus(@Param("status") String status, @Param("batchSize") int batchSize);
+
+    boolean existsByStatus(MessageStatus status);
+
+    List<Message> findAllByIdIn(List<UUID> ids);
+
+    Optional<Message> findById(UUID id);
+
+    Iterable<Message> saveAll(Iterable<Message> messages);
+}

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestrator/OrchestratorConfigRepository.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/orchestrator/OrchestratorConfigRepository.java
@@ -1,11 +1,12 @@
 package io.quintkard.quintkardapp.orchestrator;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.repository.Repository;
 
-public interface OrchestratorConfigRepository extends JpaRepository<OrchestratorConfig, UUID> {
+public interface OrchestratorConfigRepository extends Repository<OrchestratorConfig, UUID> {
+
+    OrchestratorConfig save(OrchestratorConfig orchestratorConfig);
 
     Optional<OrchestratorConfig> findByUser_UserId(String userId);
 }

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
@@ -5,6 +5,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
+import io.quintkard.quintkardapp.card.CardRepository;
+import io.quintkard.quintkardapp.card.InternalCardMaintenanceRepository;
 import io.quintkard.quintkardapp.message.MessageRepository;
 import io.quintkard.quintkardapp.messagepipeline.InternalMessageQueueRepository;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,29 @@ class TenantIsolationArchitectureTest {
         classes()
                 .that()
                 .haveFullyQualifiedName(MessageRepository.class.getName())
+                .should()
+                .notBeAssignableTo(JpaRepository.class)
+                .check(importedClasses);
+    }
+
+    @Test
+    void cardServiceAndControllerDoNotDependOnInternalCardMaintenanceRepository() {
+        noClasses()
+                .that()
+                .haveFullyQualifiedName("io.quintkard.quintkardapp.card.CardServiceImpl")
+                .or()
+                .haveFullyQualifiedName("io.quintkard.quintkardapp.card.CardController")
+                .should()
+                .dependOnClassesThat()
+                .haveFullyQualifiedName(InternalCardMaintenanceRepository.class.getName())
+                .check(importedClasses);
+    }
+
+    @Test
+    void userFacingCardRepositoryDoesNotExtendJpaRepository() {
+        classes()
+                .that()
+                .haveFullyQualifiedName(CardRepository.class.getName())
                 .should()
                 .notBeAssignableTo(JpaRepository.class)
                 .check(importedClasses);

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
@@ -1,0 +1,38 @@
+package io.quintkard.quintkardapp.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import io.quintkard.quintkardapp.message.MessageRepository;
+import io.quintkard.quintkardapp.messagepipeline.InternalMessageQueueRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+class TenantIsolationArchitectureTest {
+
+    private final JavaClasses importedClasses = new ClassFileImporter()
+            .importPackages("io.quintkard.quintkardapp");
+
+    @Test
+    void userFacingPackagesDoNotDependOnInternalMessageQueueRepository() {
+        noClasses()
+                .that()
+                .resideInAnyPackage("..message..", "..card..", "..agent..", "..orchestrator..")
+                .should()
+                .dependOnClassesThat()
+                .haveFullyQualifiedName(InternalMessageQueueRepository.class.getName())
+                .check(importedClasses);
+    }
+
+    @Test
+    void userFacingMessageRepositoryDoesNotExtendJpaRepository() {
+        classes()
+                .that()
+                .haveFullyQualifiedName(MessageRepository.class.getName())
+                .should()
+                .notBeAssignableTo(JpaRepository.class)
+                .check(importedClasses);
+    }
+}

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/architecture/TenantIsolationArchitectureTest.java
@@ -5,59 +5,50 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-import io.quintkard.quintkardapp.card.CardRepository;
-import io.quintkard.quintkardapp.card.InternalCardMaintenanceRepository;
-import io.quintkard.quintkardapp.message.MessageRepository;
-import io.quintkard.quintkardapp.messagepipeline.InternalMessageQueueRepository;
+import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 class TenantIsolationArchitectureTest {
 
     private final JavaClasses importedClasses = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
             .importPackages("io.quintkard.quintkardapp");
 
     @Test
-    void userFacingPackagesDoNotDependOnInternalMessageQueueRepository() {
+    void tenantOwnedRepositoriesDoNotExtendJpaRepository() {
+        classes()
+                .that()
+                .haveSimpleNameEndingWith("Repository")
+                .and()
+                .resideInAnyPackage("..message..", "..card..", "..agent..", "..orchestrator..")
+                .and()
+                .doNotHaveSimpleName("UserRepository")
+                .should()
+                .notBeAssignableTo(JpaRepository.class)
+                .check(importedClasses);
+    }
+
+    @Test
+    void userFacingServicesAndControllersDoNotDependOnInternalRepositories() {
         noClasses()
                 .that()
                 .resideInAnyPackage("..message..", "..card..", "..agent..", "..orchestrator..")
-                .should()
-                .dependOnClassesThat()
-                .haveFullyQualifiedName(InternalMessageQueueRepository.class.getName())
-                .check(importedClasses);
-    }
-
-    @Test
-    void userFacingMessageRepositoryDoesNotExtendJpaRepository() {
-        classes()
-                .that()
-                .haveFullyQualifiedName(MessageRepository.class.getName())
-                .should()
-                .notBeAssignableTo(JpaRepository.class)
-                .check(importedClasses);
-    }
-
-    @Test
-    void cardServiceAndControllerDoNotDependOnInternalCardMaintenanceRepository() {
-        noClasses()
-                .that()
-                .haveFullyQualifiedName("io.quintkard.quintkardapp.card.CardServiceImpl")
+                .and()
+                .haveSimpleNameEndingWith("Controller")
                 .or()
-                .haveFullyQualifiedName("io.quintkard.quintkardapp.card.CardController")
+                .haveSimpleName("MessageServiceImpl")
+                .or()
+                .haveSimpleName("CardServiceImpl")
+                .or()
+                .haveSimpleName("AgentServiceImpl")
+                .or()
+                .haveSimpleName("OrchestratorServiceImpl")
                 .should()
                 .dependOnClassesThat()
-                .haveFullyQualifiedName(InternalCardMaintenanceRepository.class.getName())
-                .check(importedClasses);
-    }
-
-    @Test
-    void userFacingCardRepositoryDoesNotExtendJpaRepository() {
-        classes()
-                .that()
-                .haveFullyQualifiedName(CardRepository.class.getName())
-                .should()
-                .notBeAssignableTo(JpaRepository.class)
+                .haveSimpleNameStartingWith("Internal")
+                .andShould()
+                .haveSimpleNameEndingWith("Repository")
                 .check(importedClasses);
     }
 }

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardEmbeddingServiceImplTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/card/CardEmbeddingServiceImplTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class CardEmbeddingServiceImplTest {
 
-    private CardRepository cardRepository;
+    private InternalCardMaintenanceRepository cardMaintenanceRepository;
     private CardEmbeddingRepository cardEmbeddingRepository;
     private EmbeddingService embeddingService;
     private CardChunkingStrategyRegistry chunkingStrategyRegistry;
@@ -30,12 +30,12 @@ class CardEmbeddingServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        cardRepository = mock(CardRepository.class);
+        cardMaintenanceRepository = mock(InternalCardMaintenanceRepository.class);
         cardEmbeddingRepository = mock(CardEmbeddingRepository.class);
         embeddingService = mock(EmbeddingService.class);
         chunkingStrategyRegistry = mock(CardChunkingStrategyRegistry.class);
         service = new CardEmbeddingServiceImpl(
-                cardRepository,
+                cardMaintenanceRepository,
                 cardEmbeddingRepository,
                 embeddingService,
                 chunkingStrategyRegistry,
@@ -48,7 +48,7 @@ class CardEmbeddingServiceImplTest {
         UUID cardId = UUID.randomUUID();
         Card card = card(cardId);
         CardChunkingStrategy strategy = mock(CardChunkingStrategy.class);
-        when(cardRepository.findById(cardId)).thenReturn(Optional.of(card));
+        when(cardMaintenanceRepository.findById(cardId)).thenReturn(Optional.of(card));
         when(chunkingStrategyRegistry.get("summary-and-content-v1")).thenReturn(strategy);
         when(strategy.chunk(card)).thenReturn(List.of());
 
@@ -69,7 +69,7 @@ class CardEmbeddingServiceImplTest {
                 new TextChunk(1, TextChunkType.CONTENT, "content one"),
                 new TextChunk(2, TextChunkType.CONTENT, "content two")
         );
-        when(cardRepository.findById(cardId)).thenReturn(Optional.of(card));
+        when(cardMaintenanceRepository.findById(cardId)).thenReturn(Optional.of(card));
         when(chunkingStrategyRegistry.get("summary-and-content-v1")).thenReturn(strategy);
         when(strategy.chunk(card)).thenReturn(chunks);
         when(embeddingService.embedAll(List.of("summary", "content one")))
@@ -99,7 +99,7 @@ class CardEmbeddingServiceImplTest {
         UUID cardId = UUID.randomUUID();
         Card card = card(cardId);
         CardChunkingStrategy strategy = mock(CardChunkingStrategy.class);
-        when(cardRepository.findById(cardId)).thenReturn(Optional.of(card));
+        when(cardMaintenanceRepository.findById(cardId)).thenReturn(Optional.of(card));
         when(chunkingStrategyRegistry.get("summary-and-content-v1")).thenReturn(strategy);
         when(strategy.chunk(card)).thenReturn(List.of(new TextChunk(0, TextChunkType.CONTENT, "content")));
         when(embeddingService.embedAll(List.of("content"))).thenReturn(List.of(new float[] {1f, 2f}));

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueServiceTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/messagepipeline/DatabaseBackedMessageQueueServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import io.quintkard.quintkardapp.config.MessageQueueProperties;
 import io.quintkard.quintkardapp.message.Message;
-import io.quintkard.quintkardapp.message.MessageRepository;
 import io.quintkard.quintkardapp.message.MessageStatus;
 import io.quintkard.quintkardapp.user.User;
 import java.time.Instant;
@@ -34,18 +33,18 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 
 class DatabaseBackedMessageQueueServiceTest {
 
-    private MessageRepository messageRepository;
+    private InternalMessageQueueRepository messageQueueRepository;
     private MessageProcessor messageProcessor;
     private ThreadPoolTaskExecutor taskExecutor;
     private DatabaseBackedMessageQueueService queueService;
 
     @BeforeEach
     void setUp() {
-        messageRepository = mock(MessageRepository.class);
+        messageQueueRepository = mock(InternalMessageQueueRepository.class);
         messageProcessor = mock(MessageProcessor.class);
         taskExecutor = mock(ThreadPoolTaskExecutor.class);
         queueService = new DatabaseBackedMessageQueueService(
-                messageRepository,
+                messageQueueRepository,
                 messageProcessor,
                 transactionManager(),
                 taskExecutor,
@@ -64,7 +63,7 @@ class DatabaseBackedMessageQueueServiceTest {
     @Test
     void processMessageMarksSuccessWhenProcessorCompletes() {
         Message message = message();
-        when(messageRepository.findById(message.getId()))
+        when(messageQueueRepository.findById(message.getId()))
                 .thenReturn(Optional.of(message), Optional.of(message));
 
         ReflectionTestUtils.invokeMethod(queueService, "processMessage", message);
@@ -76,7 +75,7 @@ class DatabaseBackedMessageQueueServiceTest {
     @Test
     void processMessageMarksFailedWhenProcessorThrows() {
         Message message = message();
-        when(messageRepository.findById(message.getId()))
+        when(messageQueueRepository.findById(message.getId()))
                 .thenReturn(Optional.of(message), Optional.of(message));
         doThrow(new IllegalStateException("boom")).when(messageProcessor).process(message);
 
@@ -88,14 +87,14 @@ class DatabaseBackedMessageQueueServiceTest {
 
     @Test
     void claimPendingMessagesReturnsEmptyWhenNoIdsClaimed() {
-        when(messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
+        when(messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
 
         @SuppressWarnings("unchecked")
         List<Message> claimed = ReflectionTestUtils.invokeMethod(queueService, "claimPendingMessages");
 
         assertEquals(List.of(), claimed);
-        verify(messageRepository, never()).findAllByIdIn(any());
-        verify(messageRepository, never()).saveAll(any());
+        verify(messageQueueRepository, never()).findAllByIdIn(any());
+        verify(messageQueueRepository, never()).saveAll(any());
     }
 
     @Test
@@ -104,9 +103,9 @@ class DatabaseBackedMessageQueueServiceTest {
         Message second = message(UUID.fromString("66666666-6666-6666-6666-666666666666"));
         UUID missingId = UUID.fromString("77777777-7777-7777-7777-777777777777");
         List<UUID> claimedIds = List.of(second.getId(), missingId, first.getId());
-        when(messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(claimedIds);
-        when(messageRepository.findAllByIdIn(claimedIds)).thenReturn(List.of(first, second));
-        when(messageRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(claimedIds);
+        when(messageQueueRepository.findAllByIdIn(claimedIds)).thenReturn(List.of(first, second));
+        when(messageQueueRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         @SuppressWarnings("unchecked")
         List<Message> claimed = ReflectionTestUtils.invokeMethod(queueService, "claimPendingMessages");
@@ -118,7 +117,7 @@ class DatabaseBackedMessageQueueServiceTest {
 
     @Test
     void processNextBatchReturnsZeroWhenNothingClaimed() {
-        when(messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
+        when(messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
 
         Integer processed = ReflectionTestUtils.invokeMethod(queueService, "processNextBatch");
 
@@ -130,7 +129,7 @@ class DatabaseBackedMessageQueueServiceTest {
     void updateMessageStatusMarksProcessingWhenRequested() {
         Message message = message();
         message.markPending();
-        when(messageRepository.findById(message.getId())).thenReturn(Optional.of(message));
+        when(messageQueueRepository.findById(message.getId())).thenReturn(Optional.of(message));
 
         ReflectionTestUtils.invokeMethod(
                 queueService,
@@ -149,8 +148,8 @@ class DatabaseBackedMessageQueueServiceTest {
             submittedWorker[0] = invocation.getArgument(0);
             return null;
         }).when(taskExecutor).execute(any(Runnable.class));
-        when(messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
-        when(messageRepository.existsByStatus(MessageStatus.PENDING)).thenReturn(true, false);
+        when(messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
+        when(messageQueueRepository.existsByStatus(MessageStatus.PENDING)).thenReturn(true, false);
 
         queueService.triggerPendingMessageProcessing();
         submittedWorker[0].run();
@@ -162,8 +161,8 @@ class DatabaseBackedMessageQueueServiceTest {
 
     @Test
     void drainPendingMessagesDoesNotRetriggerWhenNoMessagesRemain() {
-        when(messageRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
-        when(messageRepository.existsByStatus(MessageStatus.PENDING)).thenReturn(false);
+        when(messageQueueRepository.claimMessageIdsByStatus(MessageStatus.PENDING.name(), 10)).thenReturn(List.of());
+        when(messageQueueRepository.existsByStatus(MessageStatus.PENDING)).thenReturn(false);
 
         ReflectionTestUtils.setField(queueService, "workerRunning", new AtomicBoolean(true));
 


### PR DESCRIPTION
## Summary
- split user-facing message access from internal queue access
- remove broad JpaRepository exposure from the user-facing MessageRepository
- add an explicit InternalMessageQueueRepository for trusted cross-tenant queue operations
- add an ArchUnit guardrail for the first tenant-isolation boundary

## Testing
- ./gradlew test --tests 'io.quintkard.quintkardapp.message.*' --tests 'io.quintkard.quintkardapp.messagepipeline.DatabaseBackedMessageQueueServiceTest' --tests 'io.quintkard.quintkardapp.architecture.TenantIsolationArchitectureTest'

Refs #17