### PR TITLE
Add Docker-based local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ The system is designed around user-level multi-tenancy: cards, messages, agents,
 
 ## Local prerequisites
 
-- Java 21
-- Node.js
-- PostgreSQL with a `quintkard` database
-- Google Cloud auth for Gemini access
+- Docker and Docker Compose
+- Gemini access configured through either:
+  - Google Cloud Application Default Credentials for Vertex AI
+  - `GOOGLE_API_KEY` for Gemini Developer API / AI Studio
+- Java 21, Node.js, and a local PostgreSQL instance are only needed if you choose the manual non-Docker setup
 
 Default backend local DB settings are currently:
 
@@ -87,6 +88,19 @@ gcloud auth application-default login
 ```
 
 You should also make sure the configured Google Cloud project has Vertex AI access enabled.
+
+If you use the root Docker Compose setup, the backend container mounts the host ADC file from:
+
+```bash
+~/.config/gcloud/application_default_credentials.json
+```
+
+For local Docker Compose, export your host UID/GID before starting so the container can read that mounted file:
+
+```bash
+export LOCAL_UID=$(id -u)
+export LOCAL_GID=$(id -g)
+```
 
 ### Option 2: Gemini Developer API / AI Studio key
 
@@ -118,23 +132,47 @@ OpenAI is currently used for chat only. Embeddings should remain pinned to a sin
 
 ## Run locally
 
-### Local services
+### Option 1: Full stack with Docker Compose
 
-Start PostgreSQL with the provided Docker Compose file:
+Prerequisite:
+
+```bash
+Either:
+- authenticate with Google Cloud ADC using `gcloud auth application-default login`
+
+Or:
+- export `GOOGLE_API_KEY`
+```
+
+If using ADC, also export your host UID/GID so the backend container can read the mounted credentials file:
+
+```bash
+export LOCAL_UID=$(id -u)
+export LOCAL_GID=$(id -g)
+```
+
+Start the full stack from the repo root:
+
+```bash
+docker compose up --build
+```
+
+This starts:
+
+- PostgreSQL with pgvector on `localhost:5432`
+- backend API on `http://localhost:8080`
+- frontend UI on `http://localhost:3000`
+
+### Option 2: Run services manually
+
+Start PostgreSQL with the local Compose file:
 
 ```bash
 cd local
 docker compose up -d
 ```
 
-This starts:
-
-- PostgreSQL with pgvector on `localhost:5432`
-- database `quintkard`
-- username `quintkard`
-- password `quintkard`
-
-### Backend
+Then run the backend:
 
 ```bash
 cd quintkard-app
@@ -143,7 +181,7 @@ cd quintkard-app
 
 The API runs on `http://localhost:8080`.
 
-### Frontend
+Then run the frontend:
 
 ```bash
 cd quintkard-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: quintkard-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: quintkard
+      POSTGRES_USER: quintkard
+      POSTGRES_PASSWORD: quintkard
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U quintkard -d quintkard"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  quintkard-app:
+    build:
+      context: ./quintkard-app
+    container_name: quintkard-app
+    restart: unless-stopped
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/quintkard
+      SPRING_DATASOURCE_USERNAME: quintkard
+      SPRING_DATASOURCE_PASSWORD: quintkard
+      SPRING_FLYWAY_ENABLED: "true"
+      QUINTKARD_SECURITY_CORS_ALLOWED_ORIGINS: http://localhost:3000
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/application_default_credentials.json
+    ports:
+      - "8080:8080"
+    volumes:
+      - ${HOME}/.config/gcloud/application_default_credentials.json:/var/secrets/google/application_default_credentials.json:ro
+
+  quintkard-ui:
+    build:
+      context: ./quintkard-ui
+    container_name: quintkard-ui
+    restart: unless-stopped
+    depends_on:
+      - quintkard-app
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres_data:

--- a/quintkard-app/.dockerignore
+++ b/quintkard-app/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gradle
+build
+out
+*.iml
+.idea
+.DS_Store
+README.md
+HELP.md

--- a/quintkard-app/Dockerfile
+++ b/quintkard-app/Dockerfile
@@ -1,0 +1,30 @@
+FROM eclipse-temurin:21-jdk-jammy AS build
+
+WORKDIR /workspace
+
+COPY gradlew ./
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+COPY src ./src
+
+RUN chmod +x ./gradlew
+RUN ./gradlew --no-daemon bootJar
+
+
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+RUN useradd --system --create-home --uid 10001 quintkard
+RUN mkdir -p /var/secrets/google
+
+COPY --from=build /workspace/build/libs/*.jar /app/app.jar
+
+USER quintkard
+
+EXPOSE 8080
+
+ENV JAVA_OPTS=""
+ENV GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/google/application_default_credentials.json
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/quintkard-app/build.gradle
+++ b/quintkard-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.5'
+    id 'org.springframework.boot' version '4.0.6'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'jacoco'
     id "org.sonarqube" version "7.2.3.7755"
@@ -30,6 +30,7 @@ repositories {
 
 ext {
     set('springAiVersion', "2.0.0-M4")
+    set('netty.version', "4.2.13.Final")
 }
 
 dependencies {
@@ -43,7 +44,7 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'org.postgresql:postgresql:42.7.11'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-flyway-test'

--- a/quintkard-ui/.dockerignore
+++ b/quintkard-ui/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.next
+node_modules
+npm-debug.log*
+tsconfig.tsbuildinfo
+.DS_Store
+README.md

--- a/quintkard-ui/Dockerfile
+++ b/quintkard-ui/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup -S nextjs && adduser -S nextjs -G nextjs
+
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/app ./app
+COPY --from=build /app/components ./components
+COPY --from=build /app/lib ./lib
+COPY --from=build /app/next.config.ts ./next.config.ts
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/quintkard-ui/next-env.d.ts
+++ b/quintkard-ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add Dockerfiles and .dockerignore files for the backend and UI
- add a root Docker Compose stack for postgres, backend, and UI
- update README setup instructions for Docker Compose and Gemini credential prerequisites

## Notes
- the backend container is wired for host Google Application Default Credentials through a mounted ADC file
- the UI still points to the backend through the browser at http://localhost:8080
