### PR TITLE
Allow CSRF-free message ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,38 @@ npm run dev
 
 The UI runs on `http://localhost:3000`.
 
+## Send a message with curl
+
+Once the backend is running, you can ingest a message directly with `curl` using the seeded `admin` user:
+
+This ingestion endpoint is also the main HTTP entrypoint that can be used by external services or future plugins as a webhook-style integration path.
+It requires authentication, but it does not require a CSRF token.
+
+```bash
+curl -X POST http://localhost:8080/api/messages/ingest \
+  -u admin:admin \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sourceService": "gmail",
+    "externalMessageId": "sample-email-1",
+    "messageType": "EMAIL",
+    "payload": "Follow up on last year'\''s August invoice and confirm the updated account details with the vendor.",
+    "metadata": {
+      "threadId": "thread-123"
+    },
+    "details": {
+      "from": "finance@example.com"
+    },
+    "sourceCreatedAt": "2026-05-09T13:30:00Z"
+  }'
+```
+
+You can also ingest a batch through:
+
+```bash
+POST /api/messages/ingest/batch
+```
+
 ## Test and coverage
 
 Backend tests:

--- a/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
+++ b/quintkard-app/src/main/java/io/quintkard/quintkardapp/config/SecurityConfig.java
@@ -3,12 +3,14 @@ package io.quintkard.quintkardapp.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,8 +23,16 @@ public class SecurityConfig {
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        PathPatternRequestMatcher.Builder requestMatcherBuilder = PathPatternRequestMatcher.withDefaults();
+
         return httpSecurity
-                .csrf(csrf -> csrf.csrfTokenRepository(new CookieCsrfTokenRepository()))
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(new CookieCsrfTokenRepository())
+                        .ignoringRequestMatchers(
+                                requestMatcherBuilder.matcher(HttpMethod.POST, "/api/messages/ingest"),
+                                requestMatcherBuilder.matcher(HttpMethod.POST, "/api/messages/ingest/batch")
+                        )
+                )
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())

--- a/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
+++ b/quintkard-app/src/test/java/io/quintkard/quintkardapp/config/CsrfSecurityTest.java
@@ -19,9 +19,15 @@ import io.quintkard.quintkardapp.card.CardRequest;
 import io.quintkard.quintkardapp.card.CardService;
 import io.quintkard.quintkardapp.card.CardStatus;
 import io.quintkard.quintkardapp.card.CardType;
+import io.quintkard.quintkardapp.message.Message;
+import io.quintkard.quintkardapp.message.MessageEnvelope;
+import io.quintkard.quintkardapp.message.MessageIngestionController;
+import io.quintkard.quintkardapp.message.MessageIngestionService;
+import io.quintkard.quintkardapp.message.MessageStatus;
 import io.quintkard.quintkardapp.user.User;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +41,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
-@WebMvcTest(controllers = {CardController.class, CsrfController.class})
+@WebMvcTest(controllers = {CardController.class, CsrfController.class, MessageIngestionController.class})
 @Import(SecurityConfig.class)
 class CsrfSecurityTest {
 
@@ -51,6 +57,9 @@ class CsrfSecurityTest {
 
     @MockitoBean
     private CardService cardService;
+
+    @MockitoBean
+    private MessageIngestionService messageIngestionService;
 
     @MockitoBean
     private SecurityCorsProperties securityCorsProperties;
@@ -113,6 +122,23 @@ class CsrfSecurityTest {
         verify(cardService).createCard(eq("admin"), any(CardRequest.class));
     }
 
+    @Test
+    void messageIngestionEndpointIsAcceptedWithoutCsrfToken() throws Exception {
+        when(securityCorsProperties.getAllowedOrigins()).thenReturn(java.util.List.of("http://localhost:3000"));
+        when(messageIngestionService.ingestMessage(eq("admin"), any(MessageEnvelope.class))).thenReturn(message());
+
+        mockMvc.perform(post("/api/messages/ingest")
+                        .with(user("admin"))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content(messageRequestJson()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value("admin"))
+                .andExpect(jsonPath("$.sourceService").value("gmail"))
+                .andExpect(jsonPath("$.messageType").value("EMAIL"));
+
+        verify(messageIngestionService).ingestMessage(eq("admin"), any(MessageEnvelope.class));
+    }
+
     private static String cardRequestJson() {
         return """
                 {
@@ -143,5 +169,37 @@ class CsrfSecurityTest {
         ReflectionTestUtils.setField(card, "createdAt", Instant.parse("2026-04-05T00:00:00Z"));
         ReflectionTestUtils.setField(card, "updatedAt", Instant.parse("2026-04-05T01:00:00Z"));
         return card;
+    }
+
+    private static String messageRequestJson() {
+        return """
+                {
+                  "sourceService": "gmail",
+                  "externalMessageId": "ext-1",
+                  "messageType": "EMAIL",
+                  "payload": "Follow up on invoice",
+                  "metadata": {"threadId": "t-1"},
+                  "details": {"priority": "high"},
+                  "sourceCreatedAt": "2026-04-05T11:55:00Z"
+                }
+                """;
+    }
+
+    private static Message message() {
+        Message message = new Message(
+                new User("admin", "Admin", "admin@example.com", "hash", false),
+                "gmail",
+                "ext-1",
+                "EMAIL",
+                MessageStatus.PENDING,
+                "Follow up on invoice",
+                "Summary",
+                Map.of("threadId", "t-1"),
+                Map.of("priority", "high"),
+                Instant.parse("2026-04-05T12:00:00Z"),
+                Instant.parse("2026-04-05T11:55:00Z")
+        );
+        ReflectionTestUtils.setField(message, "id", UUID.randomUUID());
+        return message;
     }
 }


### PR DESCRIPTION
## Summary
- exempt message ingestion endpoints from CSRF protection
- keep CSRF protection enabled for browser-facing mutating endpoints such as card operations
- update the README curl example to note that ingestion requires authentication but not a CSRF token

## Testing
- ./gradlew test --tests "io.quintkard.quintkardapp.config.CsrfSecurityTest"
